### PR TITLE
Add keys tree

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,6 @@
 import localforage from 'localforage'
 
 import * as core from './core'
-import { CID } from './ipfs'
 import { UCAN_STORAGE_KEY, USERNAME_STORAGE_KEY } from './common'
 
 
@@ -95,7 +94,7 @@ export async function isAuthenticated(options: {
  * @param lobby Specify a custom lobby.
  */
 export async function redirectToLobby(returnTo?: string, lobby?: string): Promise<void> {
-  const did = await core.did()
+  const did = await core.did.own()
   const origin = lobby || "https://auth.fission.codes"
   const redirectTo = returnTo || window.location.href
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -94,7 +94,7 @@ export async function isAuthenticated(options: {
  * @param lobby Specify a custom lobby.
  */
 export async function redirectToLobby(returnTo?: string, lobby?: string): Promise<void> {
-  const did = await core.did.own()
+  const did = await core.did.local()
   const origin = lobby || "https://auth.fission.codes"
   const redirectTo = returnTo || window.location.href
 

--- a/src/common/arrbufs.ts
+++ b/src/common/arrbufs.ts
@@ -1,0 +1,9 @@
+export const equal = (aBuf: ArrayBuffer, bBuf: ArrayBuffer): boolean => {
+  const a = new Uint8Array(aBuf)
+  const b = new Uint8Array(bBuf)
+  if(a.length !== b.length) return false
+  for(let i=0; i<a.length; i++) {
+    if(a[i] !== b[i]) return false
+  }
+  return true
+}

--- a/src/common/crypto.ts
+++ b/src/common/crypto.ts
@@ -1,0 +1,16 @@
+import utils from 'keystore-idb/utils'
+
+export const sha256 = async (buf: ArrayBuffer): Promise<ArrayBuffer> => {
+  return window.crypto.subtle.digest(
+    {
+        name: "SHA-256",
+    },
+    buf
+  )
+}
+
+export const sha256Str = async(str: string): Promise<string> => {
+  const buf = utils.strToArrBuf(str, 8)
+  const hash = await sha256(buf)
+  return utils.arrBufToBase64(hash)
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,11 +1,12 @@
 import * as api from './api'
 import * as base64 from './base64'
 import * as blob from './blob'
+import * as arrbufs from './arrbufs'
 
 export * from './types'
 export * from './type-checks'
 export * from './util'
-export { api, base64, blob }
+export { api, base64, blob, arrbufs }
 
 export const UCAN_STORAGE_KEY = "fission_sdk.auth_ucan"
 export const USERNAME_STORAGE_KEY = "fission_sdk.auth_username"

--- a/src/core/did.ts
+++ b/src/core/did.ts
@@ -1,12 +1,112 @@
 import * as dns from '../dns'
+import * as base58 from 'base58-universal/main.js'
+import { CryptoSystem } from 'keystore-idb/types'
+import utils from 'keystore-idb/utils'
 
-export const rootDIDForUser = async (
+import { arrbufs } from '../common'
+
+import * as keystore from '../keystore'
+
+const EDW_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0xed, 0x01 ]).buffer
+const RSA_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0x00, 0xf5, 0x02 ]).buffer
+const BASE58_DID_PREFIX = 'did:key:z'
+
+/**
+ * Create a DID to authenticate with.
+ */
+export const own = async (): Promise<string> => {
+  const ks = await keystore.get()
+
+  // Public-write key
+  const pubKeyB64 = await ks.publicWriteKey()
+  return pubKeyToDid(pubKeyB64, ks.cfg.type)
+}
+
+/**
+ * Gets the root DID for a user (stored at `_did.${username}.fission.name)
+ */
+export const root = async (
   username: string,
   domain = 'fission.name'
 ): Promise<string> => {
   try {
-    return dns.lookupTxtRecord(`_did.${username}.${domain}`)
-  } catch (err) {
-    throw new Error("Could not locate user DID in dns")
+    const maybeDID = await dns.lookupTxtRecord(`_did.${username}.${domain}`)
+    if(maybeDID !== null) return maybeDID
+  } catch (_err) { }
+  throw new Error("Could not locate user DID in dns")
+}
+
+// /**
+//  * Create a DID to authenticate with.
+//  */
+// export const ownRead = async (): Promise<string> => {
+//   const ks = await keystore.get()
+
+//   // Public-write key
+//   const pubKeyB64 = await ks.publicReadKey()
+//   return pubKeyToDid(pubKeyB64, ks.cfg.type)
+// }
+
+/**
+ * Convert a base64 public key to a DID (did:key)
+ */
+export const pubKeyToDid = (pubkey: string, type: CryptoSystem): string => {
+  const pubkeyBuf = utils.base64ToArrBuf(pubkey)
+
+  // Prefix public-write key
+  const prefix = magicBytes(type) || new ArrayBuffer(0)
+  const prefixedBuf = utils.joinBufs(prefix, pubkeyBuf)
+
+  // Encode prefixed
+  return BASE58_DID_PREFIX + base58.encode(new Uint8Array(prefixedBuf))
+}
+
+/**
+ * Convert a DID (did:key) to a base64 public key
+ */
+export const didToPubKey = (did: string): string => {
+  // Ensure base58 encoded
+  if(!did.startsWith(BASE58_DID_PREFIX)){
+    throw new Error("Please use a base58-encoded DID formatted `did:key:z...`")
   }
+  const b58Encoded = did.replace(BASE58_DID_PREFIX, '')
+
+  // Ensure it's a supported key
+  const prefixedBuf = base58.decode(b58Encoded).buffer as ArrayBuffer
+  const { keyBuffer } = parseMagicBytes(prefixedBuf)
+  
+  return utils.arrBufToBase64(keyBuffer)
+}
+
+/**
+ * Magic bytes
+ */
+const magicBytes = (cryptoSystem: CryptoSystem): ArrayBuffer | null => {
+  switch (cryptoSystem) {
+    case CryptoSystem.RSA: return RSA_DID_PREFIX;
+    default: return null
+  }
+}
+
+/**
+ * Parse magic bytes on prefixed key buffer to determine cryptosystem & the unprefixed key buffer
+ */
+const parseMagicBytes = (prefixedKey: ArrayBuffer): {
+  keyBuffer: ArrayBuffer
+  type: CryptoSystem
+} => {
+  if(hasPrefix(prefixedKey, RSA_DID_PREFIX)){
+    return { 
+      keyBuffer: prefixedKey.slice(RSA_DID_PREFIX.byteLength),
+      type: CryptoSystem.RSA 
+    }
+  }
+  throw new Error("Unsupported key algorithm. Try using RSA")
+} 
+
+/**
+ * Determines if an ArrayBuffer has a given indeterminate length prefix
+ */
+const hasPrefix = (prefixedKey: ArrayBuffer, prefix: ArrayBuffer): boolean => {
+  return arrbufs.equal(prefix, prefixedKey.slice(0, prefix.byteLength))
 }

--- a/src/core/did.ts
+++ b/src/core/did.ts
@@ -1,0 +1,12 @@
+import * as dns from '../dns'
+
+export const rootDIDForUser = async (
+  username: string,
+  domain = 'fission.name'
+): Promise<string> => {
+  try {
+    return dns.lookupTxtRecord(`_did.${username}.${domain}`)
+  } catch (err) {
+    throw new Error("Could not locate user DID in dns")
+  }
+}

--- a/src/core/did.ts
+++ b/src/core/did.ts
@@ -14,7 +14,7 @@ const BASE58_DID_PREFIX = 'did:key:z'
 /**
  * Create a DID to authenticate with.
  */
-export const own = async (): Promise<string> => {
+export const local = async (): Promise<string> => {
   const ks = await keystore.get()
 
   // Public-write key
@@ -32,6 +32,17 @@ export const root = async (
   try {
     const maybeDID = await dns.lookupTxtRecord(`_did.${username}.${domain}`)
     if(maybeDID !== null) return maybeDID
+  } catch (_err) { }
+  throw new Error("Could not locate user DID in dns")
+}
+
+export const rootShareKeys = async (
+  username: string,
+  domain = 'fission.name'
+): Promise<string[]> => {
+  try {
+    const maybeDIDs = await dns.lookupTxtRecord(`_share.${username}.${domain}`)
+    if(maybeDIDs !== null) return maybeDIDs.split(',')
   } catch (_err) { }
   throw new Error("Could not locate user DID in dns")
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,32 +1,14 @@
-import * as base58 from 'base58-universal/main.js'
 import { CryptoSystem } from 'keystore-idb/types'
-import utils from 'keystore-idb/utils'
 
 import * as keystore from '../keystore'
 import { base64 } from '../common'
 
+export * as did from './did'
+export * as share from './share'
+
 
 // const EDW_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0xed, 0x01 ]).buffer
 const RSA_DID_PREFIX: ArrayBuffer = new Uint8Array([ 0x00, 0xf5, 0x02 ]).buffer
-
-
-/**
- * Create a DID to authenticate with.
- */
-export const did = async (): Promise<string> => {
-  const ks = await keystore.get()
-
-  // Public-write key
-  const pwB64 = await ks.publicWriteKey()
-  const pwBuf = utils.base64ToArrBuf(pwB64)
-
-  // Prefix public-write key
-  const prefix = magicBytes(ks.cfg.type) || new ArrayBuffer(0)
-  const prefixedBuf = utils.joinBufs(prefix, pwBuf)
-
-  // Encode prefixed
-  return 'did:key:z' + base58.encode(new Uint8Array(prefixedBuf))
-}
 
 /**
  * Create a UCAN, User Controlled Authorization Networks, JWT.
@@ -122,17 +104,6 @@ export function ucanRootIssuer(ucan: string, level = 0): string {
 function jwtAlgorithm(cryptoSystem: CryptoSystem): string | null {
   switch (cryptoSystem) {
     case CryptoSystem.RSA: return 'RS256';
-    default: return null
-  }
-}
-
-
-/**
- * Magic bytes
- */
-function magicBytes(cryptoSystem: CryptoSystem): ArrayBuffer | null {
-  switch (cryptoSystem) {
-    case CryptoSystem.RSA: return RSA_DID_PREFIX;
     default: return null
   }
 }

--- a/src/core/share.ts
+++ b/src/core/share.ts
@@ -1,9 +1,0 @@
-export const getDeviceKeys = async (username: string): Promise<string[]> => {
-  return [
-
-  ]
-}
-
-export const updateDeviceKeys = async(keys: string []): Promise<void> => {
-
-}

--- a/src/core/share.ts
+++ b/src/core/share.ts
@@ -1,0 +1,9 @@
+export const getDeviceKeys = async (username: string): Promise<string[]> => {
+  return [
+
+  ]
+}
+
+export const updateDeviceKeys = async(keys: string []): Promise<void> => {
+
+}

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -38,7 +38,7 @@ export const updateDataRoot = async (
 
   const jwt = await core.ucan({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did(),
+    issuer: await core.did.own(),
     proof: await localforage.getItem(UCAN_STORAGE_KEY)
   })
 

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -38,7 +38,7 @@ export const updateDataRoot = async (
 
   const jwt = await core.ucan({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did.own(),
+    issuer: await core.did.local(),
     proof: await localforage.getItem(UCAN_STORAGE_KEY)
   })
 

--- a/src/fs/bare/file.ts
+++ b/src/fs/bare/file.ts
@@ -10,12 +10,12 @@ export class BareFile extends BaseFile {
   }
 
   static async fromCID(cid: CID): Promise<BareFile> {
-    const content = await basic.getFile(cid, null)
+    const content = await basic.getFile(cid)
     return new BareFile(content)
   }
 
   async put(): Promise<CID> {
-    const { cid } = await  basic.putFile(this.content, null)
+    const { cid } = await  basic.putFile(this.content)
     return cid
   }
 }

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -26,6 +26,10 @@ class BareTree extends BaseTree {
     return new BareTree(links) 
   }
 
+  static fromLinks(links: Links): BareTree {
+    return new BareTree(links) 
+  }
+
   async emptyChildTree(): Promise<BareTree> {
     return BareTree.empty()
   }

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -1,4 +1,4 @@
-import pathUtil from '../path'
+import * as pathUtil from '../path'
 import { Links, Tree, File, SemVer, NonEmptyPath } from '../types'
 import check from '../types/check'
 import { CID, FileContent } from '../../ipfs'

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -16,7 +16,7 @@ type ConstructorParams = {
   publicTree: HeaderTree
   prettyTree: BareTree
   privateTree: HeaderTree
-  pinTree: BareTree
+  pinsTree: BareTree
   rootDID: string
 }
 
@@ -27,16 +27,16 @@ export class FileSystem {
   publicTree: HeaderTree
   prettyTree: BareTree
   privateTree: HeaderTree
-  pinTree: BareTree
+  pinsTree: BareTree
   rootDID: string
   syncHooks: Array<SyncHook>
 
-  constructor({ root, publicTree, prettyTree, privateTree, pinTree, rootDID }: ConstructorParams) {
+  constructor({ root, publicTree, prettyTree, privateTree, pinsTree, rootDID }: ConstructorParams) {
     this.root = root
     this.publicTree = publicTree
     this.prettyTree = prettyTree
     this.privateTree = privateTree
-    this.pinTree = pinTree
+    this.pinsTree = pinsTree
     this.rootDID = rootDID
     this.syncHooks = []
   }
@@ -47,17 +47,22 @@ export class FileSystem {
     const root = await BareTree.empty()
     const publicTree = await PublicTree.empty(null)
     const prettyTree = await BareTree.empty()
-    const pinTree = await BareTree.empty()
+    const pinsTree = await BareTree.empty()
 
     const key = await keystore.getKeyByName(keyName)
     const privateTree = await PrivateTree.empty(key)
+
+    await root.addChild('public', publicTree)
+    await root.addChild('pretty', prettyTree)
+    await root.addChild('private', privateTree)
+    await root.addChild('pins', pinsTree)
 
     return new FileSystem({
       root,
       publicTree,
       prettyTree,
       privateTree,
-      pinTree,
+      pinsTree,
       rootDID
     })
   }
@@ -73,7 +78,7 @@ export class FileSystem {
 
     const prettyTree = (await root.getDirectChild('pretty')) as BareTree ||
       await BareTree.empty()
-    const pinTree = (await root.getDirectChild('pins')) as BareTree ||
+    const pinsTree = (await root.getDirectChild('pins')) as BareTree ||
       await BareTree.empty()
 
     const privateCID = root.findLinkCID('private')
@@ -89,7 +94,7 @@ export class FileSystem {
       publicTree,
       prettyTree,
       privateTree,
-      pinTree,
+      pinsTree,
       rootDID
     })
   }
@@ -142,8 +147,8 @@ export class FileSystem {
   async updatePinTree(pins: PinMap): Promise<void> {
     // we pass `this.rootDID` as a salt
     const pinLinks = await pinMapToLinks('private', pins, this.rootDID)
-    this.pinTree = BareTree.fromLinks(pinLinks)
-    await this.root.addChild('pins', this.pinTree)
+    this.pinsTree = BareTree.fromLinks(pinLinks)
+    await this.root.addChild('pins', this.pinsTree)
   }
 
   async sync(): Promise<CID> {

--- a/src/fs/network/basic.ts
+++ b/src/fs/network/basic.ts
@@ -5,8 +5,12 @@ import { Maybe } from '../../common'
 import link from '../link'
 
 
-export const getFile = async (cid: CID, key: Maybe<string>): Promise<FileContent> => {
-  return key ? ipfs.encoded.catAndDecode(cid, key) as Promise<FileContent> : ipfs.catBuf(cid)
+export const getFile = async (cid: CID): Promise<FileContent> => {
+  return ipfs.catBuf(cid)
+}
+
+export const getEncodedFile = async (cid: CID, key: Maybe<string>): Promise<FileContent> => {
+  return ipfs.encoded.catAndDecode(cid, key) as Promise<FileContent>
 }
 
 export const getLinks = async (cid: CID, key: Maybe<string>): Promise<Links> => {
@@ -34,14 +38,20 @@ export const putLinks = async (links: BasicLinks, key: Maybe<string>): Promise<C
   }
 }
 
-export const putFile = async (content: FileContent, key: Maybe<string>): Promise<AddResult> => {
-  return key ? ipfs.encoded.add(content, key) : ipfs.add(content)
+export const putFile = async (content: FileContent): Promise<AddResult> => {
+  return ipfs.add(content)
+}
+
+export const putFileEncoded = async (content: FileContent, key: Maybe<string>): Promise<AddResult> => {
+  return ipfs.encoded.add(content, key)
 }
 
 export default {
   getFile,
+  getEncodedFile,
   getLinks,
   getLinkCID,
   putLinks,
   putFile,
+  putFileEncoded,
 }

--- a/src/fs/network/header.ts
+++ b/src/fs/network/header.ts
@@ -56,16 +56,6 @@ export const getVersion = async (cid: CID, key: Maybe<string>): Promise<SemVer> 
  * ```
  */
 
-// const pinMapToList = (pins: PinMap): CID[] => {
-//   return Object.entries(pins).reduce((acc, cur) => {
-//     const children = cur[1]
-//     return [
-//       ...acc,
-//       ...children
-//     ]
-//   }, [] as CID[])
-// }
-
 export const put = async (
     index: CID,
     header: HeaderV1,
@@ -87,12 +77,21 @@ export const put = async (
   })
   const links = link.arrToMap(linksArr)
   const cid = await basic.putLinks(links, key)
-  const pinsForHeader = linksArr.map(l => l.cid)
-  const pins = [
+
+  const pinsForHeader = linksArr.reduce((acc, cur) => ({
+    ...acc,
+    [`${cur.name}`]: cur.cid
+  }), {} as PinMap)
+
+  const pins = {
     ...pinsForHeader,
-    // ...pinMapToList(header.pins),
-    cid
-  ]
+    index: {
+      ...header.pins,
+      '': pinsForHeader.index
+    },
+    '': cid
+  }
+
   return { cid, pins }
 }
 

--- a/src/fs/network/header.ts
+++ b/src/fs/network/header.ts
@@ -56,15 +56,15 @@ export const getVersion = async (cid: CID, key: Maybe<string>): Promise<SemVer> 
  * ```
  */
 
-const pinMapToList = (pins: PinMap): CID[] => {
-  return Object.entries(pins).reduce((acc, cur) => {
-    const children = cur[1]
-    return [
-      ...acc,
-      ...children
-    ]
-  }, [] as CID[])
-}
+// const pinMapToList = (pins: PinMap): CID[] => {
+//   return Object.entries(pins).reduce((acc, cur) => {
+//     const children = cur[1]
+//     return [
+//       ...acc,
+//       ...children
+//     ]
+//   }, [] as CID[])
+// }
 
 export const put = async (
     index: CID,
@@ -90,7 +90,7 @@ export const put = async (
   const pinsForHeader = linksArr.map(l => l.cid)
   const pins = [
     ...pinsForHeader,
-    ...pinMapToList(header.pins),
+    // ...pinMapToList(header.pins),
     cid
   ]
   return { cid, pins }

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -45,3 +45,10 @@ export const nextNonEmpty = (parts: NonEmptyPath): NonEmptyPath | null => {
   }
   return next as NonEmptyPath
 }
+
+export const indexPath = (path: string): string => {
+  const parts = splitParts(path)
+  const joined =  parts.join('/index/')
+  // cut off trailing slash
+  return joined.slice(0, joined.length - 2)
+}

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -8,6 +8,13 @@ export const join = (parts: string[]): string => {
   return parts.join('/')
 }
 
+export const joinNoSuffix = (parts: string[]): string => {
+  const joined = join(parts)
+  return joined[joined.length -1] === '/' 
+          ? joined.slice(0, joined.length -1)
+          : joined
+}
+
 type HeadParts = {
   head: string | null
   nextPath: string | null
@@ -37,13 +44,4 @@ export const nextNonEmpty = (parts: NonEmptyPath): NonEmptyPath | null => {
     return null
   }
   return next as NonEmptyPath
-}
-
-
-export default {
-  splitParts,
-  join,
-  takeHead,
-  splitNonEmpty,
-  nextNonEmpty
 }

--- a/src/fs/pins.ts
+++ b/src/fs/pins.ts
@@ -1,0 +1,26 @@
+import { Links, PinMap } from "./types"
+import { isCID } from "./types/check"
+import link from "./link"
+import * as path from "./path"
+import { sha256Str } from "../common/crypto"
+
+export const pinMapToLinks = async (curPath: string, pins: PinMap, salt: string = ''): Promise<Links> => {
+  let links = {} as Links
+  const entries = Object.entries(pins)
+  for(let i=0; i<entries.length; i++){
+    const [key, val] = entries[i]
+    if(isCID(val)){
+      const name = await sha256Str(
+        path.joinNoSuffix([curPath, key]) + salt
+      )
+      links[name] = link.make(name, val, false)
+    } else {
+      const childLinks = await pinMapToLinks(path.joinNoSuffix([curPath, key]), val)
+      links = {
+        ...links,
+        ...childLinks
+      }
+    }
+  }
+  return links
+}

--- a/src/fs/pins.ts
+++ b/src/fs/pins.ts
@@ -4,7 +4,7 @@ import link from "./link"
 import * as path from "./path"
 import { sha256Str } from "../common/crypto"
 
-export const pinMapToLinks = async (curPath: string, pins: PinMap, salt: string = ''): Promise<Links> => {
+export const pinMapToLinks = async (curPath: string, pins: PinMap, salt = ''): Promise<Links> => {
   let links = {} as Links
   const entries = Object.entries(pins)
   for(let i=0; i<entries.length; i++){

--- a/src/fs/pins.ts
+++ b/src/fs/pins.ts
@@ -4,7 +4,7 @@ import link from "./link"
 import * as path from "./path"
 import { sha256Str } from "../common/crypto"
 
-export const pinMapToLinks = async (curPath: string, pins: PinMap, salt = ''): Promise<Links> => {
+export const pinMapToLinks = async (curPath: string, pins: PinMap, salt: string): Promise<Links> => {
   let links = {} as Links
   const entries = Object.entries(pins)
   for(let i=0; i<entries.length; i++){
@@ -15,7 +15,7 @@ export const pinMapToLinks = async (curPath: string, pins: PinMap, salt = ''): P
       )
       links[name] = link.make(name, val, false)
     } else {
-      const childLinks = await pinMapToLinks(path.joinNoSuffix([curPath, key]), val)
+      const childLinks = await pinMapToLinks(path.joinNoSuffix([curPath, key]), val, salt)
       links = {
         ...links,
         ...childLinks

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -8,6 +8,7 @@ import { Maybe } from '../common/types'
 export type FileSystemOptions = {
   version?: SemVer
   keyName?: string
+  rootDID?: string
 }
 
 
@@ -98,9 +99,9 @@ export type PutResult = {
 // ----
 
 export interface TreeStatic {
-  empty (parentKey: Maybe<string>): Promise<HeaderTree>
-  fromCID (cid: CID, parentKey: Maybe<string>): Promise<HeaderTree>
-  fromHeader (header: HeaderV1, parentKey: Maybe<string>): HeaderTree
+  empty(parentKey: Maybe<string>): Promise<HeaderTree>
+  fromCID(cid: CID, parentKey: Maybe<string>): Promise<HeaderTree>
+  fromHeader(header: HeaderV1, parentKey: Maybe<string>): HeaderTree
 }
 
 export interface FileStatic {
@@ -127,10 +128,10 @@ export interface Tree {
   get(path: string): Promise<Tree | File | null>
   pathExists(path: string): Promise<boolean>
   addChild(path: string, toAdd: Tree | File): Promise<this>
-  addRecurse (path: NonEmptyPath, child: Tree | FileContent): Promise<this>
+  addRecurse(path: NonEmptyPath, child: Tree | FileContent): Promise<this>
 
   put(): Promise<CID>
-  updateDirectChild (child: Tree | File, name: string): Promise<this>
+  updateDirectChild(child: Tree | File, name: string): Promise<this>
   removeDirectChild(name: string): Promise<this>
   getDirectChild(name: string): Promise<Tree | File | null>
   getOrCreateDirectChild(name: string): Promise<Tree | File>

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -67,7 +67,7 @@ export type HeaderV1 = {
   pins: PinMap
 }
 
-export type PinMap = { [cid: string]: CID[] }
+export type PinMap = { [name: string]: PinMap | CID }
 
 export type NodeInfo = HeaderV1 & {
   cid: CID

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -91,7 +91,7 @@ export type SemVer = {
 
 export type PutResult = {
   cid: CID
-  pins: CID[]
+  pins: PinMap
 }
 
 // STATIC METHODS

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -1,7 +1,10 @@
 import { isString, isObject, isNum } from '../../common'
 import { CID } from '../../ipfs'
-import { Tree, File, Link, Links, HeaderV1, NodeMap, SemVer, NodeInfo, PinMap } from '../types'
+import { Tree, File, Link, Links, HeaderV1, NodeMap, SemVer, NodeInfo, PinMap, HeaderFile, HeaderTree } from '../types'
 
+export const hasHeader = (obj: any): obj is HeaderFile | HeaderTree => {
+  return isObject(obj) && obj.getHeader !== undefined
+}
 
 export const isFile = (obj: any): obj is File => {
   return isObject(obj) && obj.content !== undefined 

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -1,6 +1,6 @@
 import PublicFile from './PublicFile'
 import { CID, FileContent } from '../../ipfs'
-import { HeaderV1, PutResult, File, HeaderFile } from '../types'
+import { HeaderV1, PutResult, HeaderFile } from '../types'
 import * as keystore from '../../keystore'
 import basic from '../network/basic'
 import header from './header'
@@ -29,7 +29,7 @@ export class PrivateFile extends PublicFile {
 
   static async fromCID(cid: CID, parentKey: string): Promise<HeaderFile>{
     const info = await header.getHeaderAndIndex(cid, parentKey)
-    const content = await basic.getFile(info.index, info.header.key)
+    const content = await basic.getEncodedFile(info.index, info.header.key)
     return new PrivateFile(content, info.header, parentKey)
   }
 

--- a/src/fs/v1/PublicFile.ts
+++ b/src/fs/v1/PublicFile.ts
@@ -29,7 +29,7 @@ export class PublicFile extends BaseFile implements HeaderFile {
 
   static async fromCID(cid: CID, parentKey: Maybe<string>): Promise<HeaderFile> {
     const info = await headerv1.getHeaderAndIndex(cid, null)
-    const content = await basic.getFile(info.index, null)
+    const content = await basic.getEncodedFile(info.index, null)
     return new PublicFile(content, info.header, parentKey)
   }
 
@@ -43,7 +43,7 @@ export class PublicFile extends BaseFile implements HeaderFile {
   }
 
   protected async putWithKey(key: Maybe<string>) {
-    const { cid, size } = await basic.putFile(this.content, this.header.key)
+    const { cid, size } = await basic.putFileEncoded(this.content, null)
     return header.put(cid, {
       ...this.header,
       size,

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -1,7 +1,7 @@
 import header from '../network/header'
 import basic from '../network/basic'
 import headerv1 from './header'
-import { Links, Tree, HeaderV1, NodeInfo, PutResult, StaticMethods, HeaderTree, HeaderFile } from '../types'
+import { Links, Tree, HeaderV1, NodeInfo, PutResult, StaticMethods, HeaderTree, HeaderFile, PinMap } from '../types'
 import check from '../types/check'
 import { CID, FileContent } from '../../ipfs'
 import BaseTree from '../base/tree'
@@ -137,7 +137,7 @@ export class PublicTree extends BaseTree implements HeaderTree {
     return this
   }
 
-  updatePins(name: string, pins: Maybe<CID[]>): this {
+  updatePins(name: string, pins: Maybe<PinMap>): this {
     this.header.pins = updateOrRemoveKeyFromObj(this.header.pins, name, pins)
     return this
   }

--- a/src/keystore/config.ts
+++ b/src/keystore/config.ts
@@ -1,11 +1,12 @@
 import keystore from 'keystore-idb'
-import { KeyStore, CryptoSystem } from 'keystore-idb/types'
+
+import { CryptoSystem } from 'keystore-idb/types'
+import { RSAKeyStore } from 'keystore-idb/rsa'
+import rsakeystore from 'keystore-idb/rsa/keystore'
 
 const KEYSTORE_CFG = { type: CryptoSystem.RSA }
 
-
-let ks: KeyStore | null = null
-
+let ks: RSAKeyStore | null = null
 
 export const clear = async (): Promise<void> => {
   if (ks) {
@@ -14,13 +15,12 @@ export const clear = async (): Promise<void> => {
   }
 }
 
-
-export const set = async (userKeystore: KeyStore): Promise<void> => {
+export const set = async (userKeystore: RSAKeyStore): Promise<void> => {
   ks = userKeystore
 }
 
-export const get = async (): Promise<KeyStore> => {
+export const get = async (): Promise<RSAKeyStore> => {
   if (ks) return ks
-  ks = await keystore.init(KEYSTORE_CFG)
+  ks = (await rsakeystore.init(KEYSTORE_CFG)) as RSAKeyStore
   return ks
 }

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -21,7 +21,7 @@ export const createAccount = async (
 
   const jwt = await core.ucan({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did.own(),
+    issuer: await core.did.local(),
   })
 
   const response = await fetch(`${apiEndpoint}/user`, {
@@ -73,7 +73,7 @@ export const makeRootUcan = async (
 
   return await core.ucan({
     audience: audience,
-    issuer: await core.did.own(),
+    issuer: await core.did.local(),
     lifetimeInSeconds,
   })
 }

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -21,7 +21,7 @@ export const createAccount = async (
 
   const jwt = await core.ucan({
     audience: await api.did(apiEndpoint),
-    issuer: await core.did(),
+    issuer: await core.did.own(),
   })
 
   const response = await fetch(`${apiEndpoint}/user`, {
@@ -73,7 +73,7 @@ export const makeRootUcan = async (
 
   return await core.ucan({
     audience: audience,
-    issuer: await core.did(),
+    issuer: await core.did.own(),
     lifetimeInSeconds,
   })
 }


### PR DESCRIPTION
## Problem
Right now the FS is being loaded by looking up a `keyName` in `keystore-idb`. This will not work across browsers and IDB could be cleared by the browser and the user would lose access to their files

## Solution
- Add a `/keys` tree to the root of the filesystem
- Add a `shareWith` function to the filesystem that encrypts the root key of a filesystem for a DID's public key and adds it to `/keys/${did}`
- Share filesystem with self when creating
- when loading a filesystem `fromCID`, check if a key has been shared with the user's DID, decrypt it, and load the private tree with that key
- reorganized some of the functions in `core` as we're adding more DID functions

## Open questions
Each user has a read key and a write key. We're storing the write key in dns. How do we publicize public read keys? Two separate DNS entries?

How to we give sub access to a user? Instead of just a key stored in `/keys`, we can also include the related cid. Add this feature now? Or in the future?