### PR TITLE
Encrypt metadata with node's key

### DIFF
--- a/src/fs/v1/header.ts
+++ b/src/fs/v1/header.ts
@@ -6,7 +6,7 @@ import { Maybe } from '../../common'
 import { CID } from '../../ipfs'
 import header, { checkValue } from '../network/header'
 
-export const values = ['name', 'isFile', 'mtime', 'size', 'version', 'key', 'fileIndex', 'pins']
+export const values = ['name', 'isFile', 'mtime', 'size', 'version', 'fileIndex', 'pins']
 
 export const empty = (): HeaderV1 => ({
   name: '',


### PR DESCRIPTION
## Problem
Currently metadata for a node is encrypted with that node's parent key (the key used to encrypt that node), not the node's own key (the key contained as a header value in that node). Thus, when a user is given access to a file, they don't get access to the metadata that goes with it

## Solution
Encrypt metadata with the node's ownKey instead of the parentKey

Closes https://github.com/fission-suite/ts-sdk/issues/53