### PR TITLE
Brooke's Familiarizing Thread 🐈🧙‍♀️

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,6 +41,7 @@ export async function isAuthenticated(options: {
   const ucan = url.searchParams.get("ucan")
 
   if (ucan) {
+    // Wait, why is this here? Mixing responsabilities?
     const newUser = url.searchParams.get("newUser") === "t"
     const username = url.searchParams.get("username") || ""
 
@@ -56,7 +57,7 @@ export async function isAuthenticated(options: {
 
     return {
       throughLobby: true,
-      authenticated: true,
+      authenticated: true, // Can't we infer that we're authenticated if we have a user? Could be brittle
       newUser,
       username
     }
@@ -68,7 +69,7 @@ export async function isAuthenticated(options: {
     }})()
 
     return {
-      throughLobby: true,
+      throughLobby: true, // Why so much session state in this function? Nothing clearly broken, but it's a code smell. Will swing back.
       authenticated: false,
       cancelled: c
     }
@@ -96,7 +97,8 @@ export async function isAuthenticated(options: {
  */
 export async function redirectToLobby(returnTo?: string, lobby?: string): Promise<void> {
   const did = await core.did()
-  const origin = lobby || "https://auth.fission.codes"
+  const origin = lobby || "https://auth.fission.codes" // These peppered throughout may be an early sign that initializing a Fission object
+                                                       // could give us flexibility via dependency injection.
   const redirectTo = returnTo || window.location.href
 
   window.location.href = origin +

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -56,4 +56,6 @@ export const asyncWaterfall = async <T>(val: T, operations: ((val: T) => Promise
     acc = await operations[i](acc)
   }
   return acc
+
+  // hmmm why not run this in parallel? Promise.all(operations)
 }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -57,5 +57,7 @@ export const asyncWaterfall = async <T>(val: T, operations: ((val: T) => Promise
   }
   return acc
 
-  // hmmm why not run this in parallel? Promise.all(operations)
+  // hmmm why not run this in parallel? Promise.all(operations.map(acc))
+  // Oooooh it's accumulating. Interesting. _Do_ these have a dependency between them?
+  // This function could be a bottleneck, but unsure
 }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -50,6 +50,7 @@ export const arrContains = <T>(arr: T[], val: T): boolean => {
 }
 
 export const asyncWaterfall = async <T>(val: T, operations: ((val: T) => Promise<T>)[]): Promise<T> => {
+  // Why not reduce?
   let acc = val
   for(let i=0; i<operations.length; i++){
     acc = await operations[i](acc)

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -15,7 +15,7 @@ import { CID } from './ipfs'
  */
 export async function dataRoot(
   username: string,
-  domain: string = "fission.name"
+  domain: string = "fission.name" // Yeah same point here about teh Fission object. Might be good to globally configure these details. May be thinking too far down the line for right now, though
 ): Promise<CID> {
   try {
     return await dns.lookupDnsLink(username + "." + domain)
@@ -31,7 +31,7 @@ export async function dataRoot(
  * @param options Use custom API endpoint and DID.
  */
 export const updateDataRoot = async (
-  cid: CID | string,
+  cid: CID | string, // Doesn't CID ~ string? This is the same as writing string | string or CID | CID. Which raises the quetsion, _should_ CID ~ string?
   options: { apiEndpoint?: string } = {}
 ): Promise<void> => {
   const apiEndpoint = options.apiEndpoint || api.defaultEndpoint()

--- a/src/fs/README.md
+++ b/src/fs/README.md
@@ -23,6 +23,9 @@ These inherit from `PublicTree` / `PublicFile`, but each node has a `parentKey` 
 
 ### Inheritance structure
 As additional versions of the FS are added, the inheritance structure will look like:
+
+<!-- Hmmmm yeah. Thinkking this though more, I'm pretty sure that we can clean this up by using [stateless functions + inheritance the other way + TS interfaces] rather than mixins. Will dig in a second here -->
+
 ```
 publicV1.0.0 -> privateV1.0.0
        |                 

--- a/src/fs/bare/file.ts
+++ b/src/fs/bare/file.ts
@@ -6,7 +6,7 @@ import BaseFile from '../base/file'
 export class BareFile extends BaseFile {
 
   static create(content: FileContent): BareFile {
-    return new BareFile(content) // why not `super`?
+    return new BareFile(content) // why not the constructor?
   }
 
   static async fromCID(cid: CID): Promise<BareFile> {

--- a/src/fs/bare/file.ts
+++ b/src/fs/bare/file.ts
@@ -6,12 +6,12 @@ import BaseFile from '../base/file'
 export class BareFile extends BaseFile {
 
   static create(content: FileContent): BareFile {
-    return new BareFile(content)
+    return new BareFile(content) // why not `super`?
   }
 
   static async fromCID(cid: CID): Promise<BareFile> {
     const content = await basic.getFile(cid, null)
-    return new BareFile(content)
+    return new BareFile(content) // why not `super`?
   }
 
   async put(): Promise<CID> {

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -17,8 +17,9 @@ class BareTree extends BaseTree {
     this.links = links
   }
 
+  // why is this async? consistent interface? if so, maybe be explicit what we're implementing
   static async empty(): Promise<BareTree> {
-    return new BareTree({})
+    return new BareTree({}) // Why not just part of the constructor as a defautl value?
   }
 
   static async fromCID(cid: CID): Promise<BareTree> {

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -16,7 +16,9 @@ abstract class BaseTree implements Tree {
     if (dir === null) {
       throw new Error("Path does not exist")
     } else if (check.isFile(dir)) {
-      throw new Error('Can not `ls` a file')
+      throw new Error('Can not `ls` a file') // Note: tell the to use cat
+                                             // Though, FYI, POSIX will just give you an array with the one file.
+                                             // Especially since it's wildcardable
     }
     return dir.getLinks()
   }
@@ -84,6 +86,8 @@ abstract class BaseTree implements Tree {
     return this.rmNested(parts)
   }
 
+  // Essentially `rm -r`, cool cool.
+  // Random idea: I wonder if passing "recursive: true" as an option would be idioamtic
   async rmNested(path: NonEmptyPath): Promise<this> {
     const filename = path[path.length - 1]
     const parentPath = path.slice(0, path.length - 1)

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -10,6 +10,7 @@ import pathUtil from './path'
 import { asyncWaterfall } from '../common/util'
 
 
+// This is by far my favourite way of handling TS params
 type ConstructorParams = {
   root: Tree
   publicTree: HeaderTree
@@ -21,8 +22,8 @@ type ConstructorParams = {
 export class FileSystem {
 
   root: Tree
-  publicTree: HeaderTree
-  prettyTree: PublicTreeBare
+  publicTree: HeaderTree // Header? UPDATE: Oooh, a tree with headers. Gotcha.
+  prettyTree: PublicTreeBare // Bare sounds like it's an empty binary tree -- this is not!
   privateTree: HeaderTree
   syncHooks: Array<SyncHook>
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -160,6 +160,7 @@ export class FileSystem {
     ]
   }
 
+  // Maybe rename to pushRemote or other familiar metaphor
   async sync(): Promise<CID> {
     // waterfall? Why not in parallel?
     this.root = await asyncWaterfall(this.root, [

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -171,6 +171,7 @@ export class FileSystem {
 
     const cid = await this.root.put()
 
+    // What are we using these hooks for?
     this.syncHooks.forEach(hook => {
       hook(cid)
     })
@@ -179,6 +180,7 @@ export class FileSystem {
   }
 
   // Legit don't know what this means: synchronize vs synchronous
+  // I don't see us actually using the sync hooks anywhere?
   addSyncHook(hook: SyncHook): Array<SyncHook> {
     this.syncHooks = [...this.syncHooks, hook]
     return this.syncHooks

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -81,6 +81,7 @@ export class FileSystem {
     })
   }
 
+  // Nice
   static async forUser(username: string, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
     const cid = await dataRoot(username)
     return FileSystem.fromCID(cid, opts)
@@ -107,6 +108,7 @@ export class FileSystem {
     })
   }
 
+  // Not sure if this is in an interface (will look), but it should! Docs, dependencies, &c.
   async ls(path: string): Promise<Links> {
     return this.runOnTree(path, false, (tree, relPath) => {
       return tree.ls(relPath)
@@ -117,7 +119,7 @@ export class FileSystem {
     await this.runOnTree(path, true, (tree, relPath) => {
       return tree.mkdir(relPath)
     })
-    return this.sync()
+    return this.sync() // Not a huge fan of the term "sync". Had to think about it a few moments to realize that it wasn't "synchronous"
   }
 
   async add(path: string, content: FileContent): Promise<CID> {
@@ -150,6 +152,7 @@ export class FileSystem {
     const privateResult = await this.privateTree.putWithPins()
     const publicResult = await this.publicTree.putWithPins()
     const rootCID = await this.sync()
+    // Minor / inconsequential -- Can be rephrased with destructuring
     return [
       ...privateResult.pins,
       ...publicResult.pins,
@@ -158,6 +161,7 @@ export class FileSystem {
   }
 
   async sync(): Promise<CID> {
+    // waterfall? Why not in parallel?
     this.root = await asyncWaterfall(this.root, [
       (t: Tree): Promise<Tree> => t.addChild('public', this.publicTree),
       (t: Tree): Promise<Tree> => t.addChild('pretty', this.prettyTree),
@@ -173,6 +177,7 @@ export class FileSystem {
     return cid
   }
 
+  // Legit don't know what this means: synchronize vs synchronous
   addSyncHook(hook: SyncHook): Array<SyncHook> {
     this.syncHooks = [...this.syncHooks, hook]
     return this.syncHooks
@@ -192,6 +197,7 @@ export class FileSystem {
     const head = parts[0]
     const relPath = pathUtil.join(parts.slice(1))
 
+    // Why `a` not FileSystem? TS has subtyping. I easily could be missing something.
     let result: a
     let resultPretty: a
 
@@ -212,6 +218,7 @@ export class FileSystem {
         this.privateTree = result
       }
 
+      // NOTE TO SELF: pretty ~ reduction ~ view pattern
     } else if (head === 'pretty' && updateTree) {
       throw new Error("The pretty path is read only")
 

--- a/src/fs/link.ts
+++ b/src/fs/link.ts
@@ -10,6 +10,7 @@ export const toDAGLink = (link: BasicLink): DAGLink => {
   return new dagPB.DAGLink(name, size, cid)
 }
 
+// Consistent naming would be helpful -- fromUnixFSFile
 export const fromFSFile = (fsObj: UnixFSFile): Link => {
   const { name = '', cid, size, mtime, type } = fsObj
   return {
@@ -21,6 +22,7 @@ export const fromFSFile = (fsObj: UnixFSFile): Link => {
   }
 }
 
+// NodeMeta?
 export const fromNodeMap = (nodes: NodeMap): Links => {
   return mapObj(nodes, val => {
     const { name = '', cid, size, mtime, isFile } = val
@@ -28,6 +30,7 @@ export const fromNodeMap = (nodes: NodeMap): Links => {
   })
 }
 
+// Why not `new Link(...)`?
 export const make = (name: string, cid: string, isFile: boolean, size?: number): Link => {
   return {
     name,
@@ -38,6 +41,7 @@ export const make = (name: string, cid: string, isFile: boolean, size?: number):
   }
 }
 
+// Link.join([...])?
 export const arrToMap = (arr: Link[]): Links => {
   return arr.reduce((acc, cur) => {
     acc[cur.name] = cur

--- a/src/fs/network/basic.ts
+++ b/src/fs/network/basic.ts
@@ -1,3 +1,5 @@
+// Hmm, not sure if this file belongs in fs
+//
 import ipfs, { CID, FileContent, AddResult } from '../../ipfs'
 
 import { Links, BasicLinks } from '../types'

--- a/src/fs/network/header.ts
+++ b/src/fs/network/header.ts
@@ -133,6 +133,7 @@ export const getHeader = async (
   }, {} as UnstructuredHeader)
 }
 
+// looks like a parser. Design pattern suggestion: "parse, don't validate"
 export const checkValue = <T>(val: any, checkFn: (val: any) => val is T, canBeNull = false): T => {
   if(!isValue(val)){
     if(canBeNull) return val

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -1,7 +1,8 @@
 import { NonEmptyPath } from './types'
 
+// segments
 export const splitParts = (path: string): string[] => {
-  return path.split('/').filter(p => p.length > 0)
+  return path.split('/').filter(p => p.length > 0) // why not `p == ''`
 }
 
 export const join = (parts: string[]): string => {
@@ -25,7 +26,7 @@ export const takeHead = (path: string): HeadParts => {
 
 export const splitNonEmpty = (path: string): NonEmptyPath | null => {
   const parts = splitParts(path)
-  if (parts.length < 1) {
+  if (parts.length < 1) { // === 0?
     return null
   }
   return parts as NonEmptyPath
@@ -33,7 +34,7 @@ export const splitNonEmpty = (path: string): NonEmptyPath | null => {
 
 export const nextNonEmpty = (parts: NonEmptyPath): NonEmptyPath | null => {
   const next = parts.slice(1)
-  if (next.length < 1) {
+  if (next.length < 1) { // === 0
     return null
   }
   return next as NonEmptyPath

--- a/src/fs/semver.ts
+++ b/src/fs/semver.ts
@@ -27,7 +27,7 @@ const toString = (version: SemVer): string => {
   return `${major}.${minor}.${patch}`
 }
 
-const v0 = encode(0, 0, 0)
+const v0 = encode(0, 0, 0) // Hmm I wonder if we can do comparisons `version < Major(1)`
 const v1 = encode(1, 0, 0)
 const latest = encode(1, 0, 0)
 

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -118,6 +118,7 @@ export interface StaticMethods {
 // TREE
 // ----
 
+// Break into parts
 export interface Tree {
   version: SemVer
 

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -2,6 +2,8 @@ import { FileContent, CID } from '../ipfs'
 import { Maybe } from '../common/types'
 
 
+// NOTE: could be broken into separate files, unless these are recursively defined
+
 // FILESYSTEM
 // -----
 

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -19,6 +19,8 @@ export class PublicTree extends BaseTree implements HeaderTree {
   protected ownKey: Maybe<string> = null // what is this?
     // UPDATE: this is a placeholder for a nonexistant encryption key
 
+  // Fine with this, and will be a pattern that we use for a few things,
+    // but also why not just inherited?
   protected static: StaticMethods
 
   constructor(header: HeaderV1, parentKey: Maybe<string>) {

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -33,6 +33,7 @@ export class PublicTree extends BaseTree implements HeaderTree {
     }
   }
 
+  // Wait wait... why async?
   static async empty (parentKey: Maybe<string>): Promise<HeaderTree> {
     return new PublicTree({
       ...headerv1.empty(),

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -13,8 +13,10 @@ import semver from '../semver'
 export class PublicTree extends BaseTree implements HeaderTree {
 
   protected header: HeaderV1
-  protected parentKey: Maybe<string>
-  protected ownKey: Maybe<string> = null
+  protected parentKey: Maybe<string> // Oooooh this will likely make life harder
+                                     // Suddenly you have a dependency on the entire tree
+
+  protected ownKey: Maybe<string> = null // what is this?
 
   protected static: StaticMethods
 

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -48,6 +48,7 @@ export class PublicTree extends BaseTree implements HeaderTree {
     return obj.header !== undefined
   }
 
+  // Why?
   async emptyChildTree(): Promise<HeaderTree> {
     return this.static.tree.empty(this.ownKey)
   }

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -17,6 +17,7 @@ export class PublicTree extends BaseTree implements HeaderTree {
                                      // Suddenly you have a dependency on the entire tree
 
   protected ownKey: Maybe<string> = null // what is this?
+    // UPDATE: this is a placeholder for a nonexistant encryption key
 
   protected static: StaticMethods
 

--- a/src/fs/v1/header.ts
+++ b/src/fs/v1/header.ts
@@ -6,6 +6,7 @@ import { Maybe } from '../../common'
 import { CID } from '../../ipfs'
 import header, { checkValue } from '../network/header'
 
+// Why not use the TS Keys?
 export const values = ['name', 'isFile', 'mtime', 'size', 'version', 'key', 'fileIndex', 'pins']
 
 export const empty = (): HeaderV1 => ({
@@ -25,9 +26,9 @@ type Result = {
 }
 
 export const getHeaderAndIndex = async (cid: CID, parentKey: Maybe<string>): Promise<Result> => {
-  const result = await header.getHeaderAndIndex(cid, parentKey, values)
+  const result = await header.getHeaderAndIndex(cid, parentKey, values) // ??
   const unstructured = result.header
-  const headerVal = parseAndCheck(unstructured)
+  const headerVal = parseAndCheck(unstructured) // `And` is a smell
   return { index: result.index, header: headerVal }
 }
 

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -7,6 +7,7 @@ export type IPFS = {
   dns(domain: string): Promise<CID>
 }
 
+// Serializatin only
 export type DAGNode = {
   Links: DAGLink[]
   size: number
@@ -16,6 +17,7 @@ export type DAGNode = {
   toJSON: () => object
 }
 
+// Serialziation only
 export type DAGLink = {
   Name: string
   Hash: string
@@ -62,21 +64,27 @@ export type CIDObj = {
   version: number
 }
 
+// Why have Content and ContentRaw separate?
 export type FileContent = object | Blob | string | number | boolean
 export type FileContentRaw = Buffer
 
+// Why?
 export type FileMode = number
 
+// Is this an IPFS type, or ours?
+// ANSWER: it's the built-in one
 export type UnixFSFile = {
   cid: CIDObj
   path: string
   size: number
-  mode?: FileMode
-  mtime?: number
-  name?: string
-  type?: string
+  mode?: FileMode // UCAN
+  mtime?: number  // I'm divided on this one, because distributed systems and clock drift
+                  // We may stamp each generation instead?
+  name?: string   // Handle with structural links
+  type?: string   // Ya, probably a good idea. Extension if nothing else
 }
 
+// cool cool
 export type ObjStat = {
   Hash: string
   NumLinks: number
@@ -86,6 +94,7 @@ export type ObjStat = {
   CumulativeSize: number
 }
 
+// What is "Add Result"? Could use better naming
 export type AddResult = {
   cid: CID
   size: number

--- a/src/keystore/basic.ts
+++ b/src/keystore/basic.ts
@@ -1,3 +1,5 @@
+// Consider breaking down by theme (e.g. crypto, I/O, &c)
+
 import aes from 'keystore-idb/aes'
 import * as keystore from './config'
 

--- a/src/keystore/config.ts
+++ b/src/keystore/config.ts
@@ -20,6 +20,7 @@ export const set = async (userKeystore: KeyStore): Promise<void> => {
   ks = userKeystore
 }
 
+// This looks a lot like a constructor
 export const get = async (): Promise<KeyStore> => {
   if (ks) return ks
   ks = await keystore.init(KEYSTORE_CFG)

--- a/src/keystore/config.ts
+++ b/src/keystore/config.ts
@@ -4,6 +4,7 @@ import { KeyStore, CryptoSystem } from 'keystore-idb/types'
 const KEYSTORE_CFG = { type: CryptoSystem.RSA }
 
 
+// Is the keystore a singleton?
 let ks: KeyStore | null = null
 
 

--- a/src/lobby/blocklist.ts
+++ b/src/lobby/blocklist.ts
@@ -1,4 +1,4 @@
-// "Lobby"? I'm not following the metamor/convention. Halp!
+// "Lobby"? I'm not following the metaphor/convention. Halp!
 
 
 /**
@@ -7,6 +7,12 @@
  * Keep in sync with the Fission API.
  * https://github.com/fission-suite/fission/blob/master/library/Fission/User/Username/Validation.hs
  */
+
+
+// Hmmm ya I remember talking about this before.
+// We also have this list on the server, where it's actually longer
+// Probs needs to be updated. I'm fine with maintaining this by hand.
+// How often does it get changed really?
 export const USERNAME_BLOCKLIST =
   [ "fission"
   , "ipfs"

--- a/src/lobby/blocklist.ts
+++ b/src/lobby/blocklist.ts
@@ -1,3 +1,6 @@
+// "Lobby"? I'm not following the metamor/convention. Halp!
+
+
 /**
  * Blocklist for usernames.
  *

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -1,3 +1,7 @@
+// Suggestion -- index could perhaps be reexports only
+// I almost skipped this file thinking that's what it was
+// I realize that this is a common pattern, but it may be cleaner. Thoughts?
+
 import * as core from '../core'
 import { api } from '../common'
 import { dataRoot } from '../data-root'


### PR DESCRIPTION
I'm purely using this branch as a way to make notes and get familiar with the code. Also a good way to communicate async about why things are the way they are.

I want to clarify that most/many of these questions are asked humbly, and are not criticisms. Really just looking for clarity on design decisions long before potentially suggesting anything.

---

Current game plan:

* Break out multiple (abstract) interfaces
* Parse, don't validate
* ~~`async empty()` -> `constructor({...} = {})`~~
  * ~~Drop the async here, too~~
    * Yeah, need the `async` because key generation. Womp womp.
  * Rearrange AES keys to _not reference_ parent
    * Multiple options here, including passing them in as an explicit parameter, changing the keys, &c
* Abstractions
  * Likely tree operations, such as `walk`, `map`, and `fold`
  * Serialization, serialization functions (plural)
    * Break out as a _separate_ step
    * Render to plain JSON -- helpful for model testing
* Helpers
  * Why not write an `asyncReduce` or `reduce(fn, {async: true}, collection)`?
    * Underneath, it _is just a `for` loop_
* POSSIBLY
  * Fold `pretty` and `FLOOFS` into the same structure, recursively
  * Make the entire tree fully recursive, with each branch having an optional key?
    * Eh, probably not. Very flexible, but fewer invariants. Worth exploring, though.
    * Hmm, yeah. Actually we can have optional pointers from each abstract layer.
    * May not be able to enforce recursive encryption in types, though 🤔
  * Lazy building
    * This may cause more complexity than it solves. Why not just hydrate on pull?
      * I guess it could get large, but like... is that so bad? 10ks of objects I guess 🤔
      * These are isomorphic, so it does keep space under controkl
    * Should be able to `.toJSON` any inode to deterministically get a JSON cache representation
  * _Maybe_ drop the recursive index.json from the public side? It should be pretty small overall. Not sure though.

```haskell
-- Something like:

data FileSystem
  = Abstract Layer (Either Pretty Private)
  | PrivateLayer Private
```

Yes, actually something interesting in that direction:

```haskell
-- Term `Inode` comes from "index node" https://www.wikiwand.com/en/Inode
-- The following is modelled structurally rather than OO. YMMV.

data FileSystem
  | Root (Inode Public) (Inode Private) KeyExchange
  | Public (Inode Public)
  | Private (Inode Private)

data Inode a = Inode
  { meta    :: Metadata a
  , content :: Either RawFile { Text => Inode a }
  }

-- Abusing notation since this is a sketch. Would be a GADT or data family IRL.

data Metadata a = Metadata
  { bytes    :: Natural
  , event    :: Event
  , previous :: Inode a
  , special  :: a -- AES key, pretty CID, and whatnot
  }
```

```haskell
-- partially alternate design

data PublicInode = PublicInode
  { metadata :: Metadata
  , content  :: Either RawFile { Text => PublicInode }
  , direct   :: (FileContent, CID) -- recursive "pretty" path
  }

-- Now the two parts stack directly
```

---

Primitive operations:

* Network
  * Push
  * Pull
* Local
  * Read
  * Write
* Serialization
  * Serialize to IPLD
  * Parse from IPLD
  * Serialize to JSON
  * Parse to JSON
* Inode
  * Mutate Inode links
    * Add link
    * Remove link
    * Rename link
      * Property: same as remove and add updated
  * Query Inode -- actually probably a path transform would be the _primitive_, to call into
                -- or heck, `find` (a path selector)
    * Index (ls)
    * Show (cat)
    * Inspect (meta)
    * Get path segments (e.g. for building IPLD path or pretty URL)
  * Mutate Inode Metadata
    * Add
    * Remove
    * Update
  * Query Metadata
    * Read
  * File
    * Update content
    * Read raw