### PR TITLE
bugfix: if no private tree when loading WNFS, create new

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -157,13 +157,16 @@ export class FileSystem implements UnixTree {
                         await BareTree.empty()
 
     const privateCID = root.links['private']?.cid || null
-
-    const mmpt = privateCID === null
-      ? await MMPT.create()
-      : await MMPT.fromCID(privateCID)
-
     const key = await keystore.getKeyByName(keyName)
-    const privateTree = await PrivateTree.fromBaseKey(mmpt, key)
+
+    let mmpt, privateTree
+    if(privateCID === null){
+      mmpt = await MMPT.create()
+      privateTree = await PrivateTree.create(mmpt, key, null)
+    }else{
+      mmpt = await MMPT.fromCID(privateCID)
+      privateTree = await PrivateTree.fromBaseKey(mmpt, key)
+    }
 
     const fs = new FileSystem({
       root,


### PR DESCRIPTION
## Problem
When loading WNFS from a CID & a private branch does not exist, it will create a new private MMPT, but will attempt to load the root of the private tree as if it exists, causing an error

## Solution
Create a new MMPT & create a new private tree root