### PR TITLE
AES-256

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "borc": "^2.1.1",
     "fission-bloom-filters": "^1.4.0",
     "ipld-dag-pb": "^0.18.2",
-    "keystore-idb": "^0.13.3",
+    "keystore-idb": "^0.13.4",
     "load-script2": "^2.0.5",
     "localforage": "^1.7.3",
     "make-error": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "borc": "^2.1.1",
     "fission-bloom-filters": "^1.4.0",
     "ipld-dag-pb": "^0.18.2",
-    "keystore-idb": "^0.13.0",
+    "keystore-idb": "^0.13.3",
     "load-script2": "^2.0.5",
     "localforage": "^1.7.3",
     "make-error": "^1.3.6",

--- a/src/keystore/basic.ts
+++ b/src/keystore/basic.ts
@@ -1,4 +1,5 @@
 import aes from 'keystore-idb/aes'
+import { SymmKeyLength } from 'keystore-idb/types'
 import { strToArrBuf } from 'keystore-idb/utils'
 import * as keystore from './config'
 import * as hex from '../common/hex'
@@ -22,7 +23,7 @@ export const decrypt = async (encrypted: Uint8Array, keyStr: string): Promise<Ui
 }
 
 export const genKeyStr = async (): Promise<string> => {
-  const key = await aes.makeKey()
+  const key = await aes.makeKey({ length: SymmKeyLength.B256 })
   return aes.exportKey(key)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,10 +2876,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keystore-idb@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.0.tgz#8c852b7e69cf4cf9a864f502ca10f2c193a217f9"
-  integrity sha512-dGE1Hca3Z8TV8hL0CXuVMYt5L5ZvCTFWy4cR3a885xRT9JeDExpFaI1m2KBqPn/zkrFvIyg7Q6x26U7fRH7MAA==
+keystore-idb@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.3.tgz#405b76a935978a751c0d70be28e19d8e887d53f2"
+  integrity sha512-EZNwnbXW71ODi6MLKN89GD7Yhoa17sPN9zKopbW/bTy3Bkf1X8lL56Jj15YBsv7SHoDzEmI/BIF6G56bdeTw5g==
   dependencies:
     localforage "^1.7.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,10 +2876,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keystore-idb@^0.13.3:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.3.tgz#405b76a935978a751c0d70be28e19d8e887d53f2"
-  integrity sha512-EZNwnbXW71ODi6MLKN89GD7Yhoa17sPN9zKopbW/bTy3Bkf1X8lL56Jj15YBsv7SHoDzEmI/BIF6G56bdeTw5g==
+keystore-idb@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.4.tgz#b2736ee183ce2767f93b59f61bbc7ad5fd20d6e2"
+  integrity sha512-jXYiTCebOUgz5qOwh9v3BoppUed3kNF9Xn55CZz3kmAKA3Ic0phB+Vx00yxnzlx6hQC0nce6txAi37TI046bZg==
   dependencies:
     localforage "^1.7.3"
 


### PR DESCRIPTION
## Problem
We should be using to AES-256 for extra security & quantum resistance

## Solution
- bump keystore-idb to `0.13.3` for AES-256 default
- hardcode AES-256 for WNFS