### PR TITLE
Cidv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.17.1
+
+- Upgrade to CIDv1
+
 
 ### v0.17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -7,7 +7,7 @@ import { DAG_NODE_DATA } from './constants'
 
 export const add = async (content: FileContent): Promise<AddResult> => {
   const ipfs = await getIpfs()
-  const result = await ipfs.add(content)
+  const result = await ipfs.add(content, { cidVersion: 1 })
 
   return {
     cid: result.cid.toString(),
@@ -51,9 +51,10 @@ export const dagGet = async (cid: CID): Promise<DAGNode> => {
 
 export const dagPut = async (node: DAGNode): Promise<AddResult> => {
   const ipfs = await getIpfs()
-  // using this format so that we get v0 CIDs. ipfs gateway seems to have issues w/ v1 CIDs
+  // using this format because Gateway doesn't like `dag-cbor` nodes. 
+  // I think this is because UnixFS requires `dag-pb` & the gateway requires UnixFS for directory traversal
   const cidObj = await ipfs.dag.put(node, { format: 'dag-pb', hashAlg: 'sha2-256' })
-  const cid = cidObj.toString()
+  const cid = cidObj.toV1().toString()
   const nodeSize = await size(cid)
   return { cid, size: nodeSize }
 }

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -41,7 +41,7 @@ export type RawDAGLink = {
 }
 
 export interface DagAPI {
-  put(dagNode: unknown, options: unknown): Promise<CIDObj>
+  put(dagNode: unknown, options?: unknown): Promise<CIDObj>
   get(cid: string | CID, path?: string, options?: unknown): Promise<RawDAGNode>
   resolve(cid: string | CID | CIDObj): Promise<{ cid: CIDObj }>
   tree(cid: string | CID, path?: string, options?: unknown): Promise<Array<string>>
@@ -67,6 +67,8 @@ export type CIDObj = {
   multibaseName: MultibaseName
   string: CID
   version: number
+  toV1(): CIDObj
+  toString(): string
 }
 
 export type FileContent = Record<string, unknown> | Buffer | Blob | string | number | boolean


### PR DESCRIPTION
## Problem
We're still using CIDv0. CIDv1 are the new standard, no longer experimental & are case-insensitive so can be used in domains

## Solution
Upgrade IPFS CIDs to v1
- [x] files
- [x] dag nodes