### PR TITLE
Add IPFS Delegate Node

### DIFF
--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -11,6 +11,7 @@ type IpfsWindow = {
 
 export const JS_IPFS = 'https://cdnjs.cloudflare.com/ajax/libs/ipfs/0.48.1/index.min.js'
 export const PEER_WSS = '/dns4/node.fission.systems/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw'
+export const DELEGATE_ADDR = '/dns4/ipfs.runfission.com/tcp/443/https'
 
 
 let ipfs: IPFS | null = null
@@ -19,7 +20,7 @@ let ipfs: IPFS | null = null
 export const defaultOptions = {
   config: {
     Addresses: {
-      Delegates: [ PEER_WSS ]
+      Delegates: [ DELEGATE_ADDR ]
     },
    Bootstrap: [ PEER_WSS ]
   }


### PR DESCRIPTION
## Problem
Content routing is no good in the browser

## Solution
Delegate content/peer routing to our remote node

This delegation occurs of https, so we direct it to the http public gateway instead of the websockets p2p port