### PR TITLE
Reorganize initialise return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ###### Breaking changes
 
-- Decrypt `readKey` from auth lobby
 - Renamed `publicise`/`publicize` to `publish`
 - Renamed `prerequisites` to `permissions`
 - The `app` and `fs` params to `initialise` are now grouped together by passing the `permissions` parameter.
+- Decrypt `readKey` from auth lobby (behind the scenes)
 
 
 ### v0.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.18.0
 
-### Breaking changes
+###### Breaking changes
 
 - Decrypt `readKey` from auth lobby
 - Renamed `publicise`/`publicize` to `publish`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### v0.18.0
+
+### Breaking changes
+
+- Decrypt `readKey` from auth lobby
+- Renamed `publicise`/`publicize` to `publish`
+- Renamed `prerequisites` to `permissions`
+- The `app` and `fs` params to `initialise` are now grouped together by passing the `permissions` parameter.
+
+
 ### v0.17.3
 
 Upgrade to js-ipfs v0.50

--- a/README.md
+++ b/README.md
@@ -42,19 +42,22 @@ See [`docs/`](docs/) for more detailed documentation based on the source code.
 
 ```ts
 const state = await wn.initialise({
-  // Will ask the user permission to store
-  // your apps data in `private/Apps/Nullsoft/Winamp`
-  app: {
-    name: "Winamp",
-    creator: "Nullsoft"
-  },
+  permissions: {
+    // Will ask the user permission to store
+    // your apps data in `private/Apps/Nullsoft/Winamp`
+    app: {
+      name: "Winamp",
+      creator: "Nullsoft"
+    },
 
-  // Ask the user permission for additional filesystem paths
-  fs: {
-    privatePaths: [ "Music" ],
-    publicPaths: [ "Mixtapes" ]
+    // Ask the user permission for additional filesystem paths
+    fs: {
+      privatePaths: [ "Music" ],
+      publicPaths: [ "Mixtapes" ]
+    }
   }
 })
+
 
 switch (state.scenario) {
 
@@ -76,7 +79,7 @@ switch (state.scenario) {
     break;
 
   case wn.NotAuthorised:
-    wn.redirectToLobby(permissions)
+    wn.redirectToLobby(state.permissions)
     break;
 
 }

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [`docs/`](docs/) for more detailed documentation based on the source code.
 # Authentication
 
 ```ts
-const { prerequisites, scenario, state } = await wn.initialise({
+const state = await wn.initialise({
   // Will ask the user permission to store
   // your apps data in `private/Apps/Nullsoft/Winamp`
   app: {
@@ -56,22 +56,28 @@ const { prerequisites, scenario, state } = await wn.initialise({
   }
 })
 
-if (scenario.authCancelled) {
-  // User was redirected to lobby,
-  // but cancelled the authorisation.
+switch (state.scenario) {
 
-} else if (scenario.authSucceeded || scenario.continuation) {
-  // State:
-  // state.authenticated    -  Will always be `true` in these scenarios
-  // state.newUser          -  If the user is new to Fission
-  // state.throughLobby     -  If the user authenticated through the lobby, or just came back.
-  // state.username         -  The user's username.
-  //
-  // ☞ We can now interact with our file system (more on that later)
-  state.fs
+  case wn.AuthCancelled:
+    // User was redirected to lobby,
+    // but cancelled the authorisation
+    break;
 
-} else if (scenario.notAuthorised) {
-  wn.redirectToLobby(prerequisites)
+  case wn.AuthSucceeded:
+  case wn.Continuation:
+    // State:
+    // state.authenticated    -  Will always be `true` in these scenarios
+    // state.newUser          -  If the user is new to Fission
+    // state.throughLobby     -  If the user authenticated through the lobby, or just came back.
+    // state.username         -  The user's username.
+    //
+    // ☞ We can now interact with our file system (more on that later)
+    state.fs
+    break;
+
+  case wn.NotAuthorised:
+    wn.redirectToLobby(permissions)
+    break;
 
 }
 ```
@@ -100,13 +106,13 @@ if (await fs.exists(appPath)) {
 // The user is new to the app, lets create the app-data directory.
 } else {
   await fs.mkdir(appPath)
-  await fs.publicise()
+  await fs.publish()
 
 }
 
 // Create a sub directory
 await fs.mkdir(fs.appPath([ "Sub Directory" ]))
-await fs.publicise()
+await fs.publish()
 ```
 
 
@@ -124,9 +130,9 @@ WNFS exposes a familiar POSIX-style interface:
 - `write`: alias for `add`
 
 
-## Publicise
+## Publish
 
-The `publicise` function synchronises your file system with the Fission API and IPFS. We don't do this automatically because if you add a large set of data, you only want to do this after everything is added. Otherwise it would be too slow and we would have too many network requests to the API.
+The `publish` function synchronises your file system with the Fission API and IPFS. We don't do this automatically because if you add a large set of data, you only want to do this after everything is added. Otherwise it would be too slow and we would have too many network requests to the API.
 
 
 
@@ -144,13 +150,12 @@ yarn build
 
 # test
 yarn test
-
-# test w/ reloading
 yarn test:watch
 
 # generate docs
 yarn docs
 
 # publish (run this script instead of npm publish!)
-./publish.sh
+just publish
+just publish-alpha
 ```

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ const state = await wn.initialise({
 
 switch (state.scenario) {
 
-  case wn.AuthCancelled:
+  case wn.Scenario.AuthCancelled:
     // User was redirected to lobby,
     // but cancelled the authorisation
     break;
 
-  case wn.AuthSucceeded:
-  case wn.Continuation:
+  case wn.Scenario.AuthSucceeded:
+  case wn.Scenario.Continuation:
     // State:
     // state.authenticated    -  Will always be `true` in these scenarios
     // state.newUser          -  If the user is new to Fission
@@ -78,7 +78,7 @@ switch (state.scenario) {
     state.fs
     break;
 
-  case wn.NotAuthorised:
+  case wn.Scenario.NotAuthorised:
     wn.redirectToLobby(state.permissions)
     break;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.17.3",
+  "version": "0.18.0",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -36,17 +36,18 @@ export async function leave(): Promise<void> {
  * NOTE: Only works on the main thread, as it uses `window.location`.
  *
  * @param prerequisites The prerequisites from `initialise`
- * @param returnTo Specify the URL you want users to return to.
- *                 Uses the current url by default.
+ * @param redirectTo Specify the URL you want users to return to.
+ *                   Uses the current url by default.
  */
 export async function redirectToLobby(
   prerequisites: Prerequisites,
-  returnTo?: string
+  redirectTo?: string
 ): Promise<void> {
   const { app, fs } = prerequisites
   const exchangeDid = await did.exchange()
   const writeDid = await did.write()
-  const redirectTo = returnTo || window.location.href
+
+  redirectTo = redirectTo || window.location.href
 
   // Compile params
   const params = [

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import * as common from './common'
 import * as did from './did'
 import * as ucan from './ucan/internal'
 import { UCANS_STORAGE_KEY, USERNAME_STORAGE_KEY } from './common'
-import { Prerequisites } from './ucan/prerequisites'
+import { Permissions } from './ucan/permissions'
 import { setup } from './setup/internal'
 
 
@@ -35,15 +35,15 @@ export async function leave(): Promise<void> {
  *
  * NOTE: Only works on the main thread, as it uses `window.location`.
  *
- * @param prerequisites The prerequisites from `initialise`
+ * @param permissions The permissions from `initialise`
  * @param redirectTo Specify the URL you want users to return to.
  *                   Uses the current url by default.
  */
 export async function redirectToLobby(
-  prerequisites: Prerequisites,
+  permissions: Permissions,
   redirectTo?: string
 ): Promise<void> {
-  const { app, fs } = prerequisites
+  const { app, fs } = permissions
   const exchangeDid = await did.exchange()
   const writeDid = await did.write()
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -84,5 +84,5 @@ async function addSampleData(fs: FileSystem): Promise<void> {
   await fs.mkdir("private/Documents")
   await fs.mkdir("private/Photos")
   await fs.mkdir("private/Video")
-  await fs.publicise()
+  await fs.publish()
 }

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -5,20 +5,20 @@ import * as cidLog from './common/cid-log'
 import * as debug from './common/debug'
 import * as dataRoot from './data-root'
 import { READ_KEY_FROM_LOBBY_NAME, authenticatedUsername } from './common'
-import { Prerequisites } from './ucan/prerequisites'
+import { Permissions } from './ucan/permissions'
 import { Ucan } from './ucan'
 
 
 /**
  * Load a user's file system.
  *
- * @param prerequisites The prerequisites from initialise.
+ * @param permissions The permissions from initialise.
  * @param username Optional, username of the user to load the file system from.
  *                 Will try to load the file system of the authenticated user
  *                 by default. Throws an error if there's no authenticated user.
  */
 export async function loadFileSystem(
-  prerequisites: Prerequisites,
+  permissions: Permissions,
   username?: string
 ): Promise<FileSystem> {
   let cid, fs
@@ -62,11 +62,11 @@ export async function loadFileSystem(
 
   // If a file system exists, load it and return it
   const keyName = READ_KEY_FROM_LOBBY_NAME
-  fs = cid ? await FileSystem.fromCID(cid, { keyName, prerequisites }) : null
+  fs = cid ? await FileSystem.fromCID(cid, { keyName, permissions }) : null
   if (fs) return fs
 
   // Otherwise make a new one
-  fs = await FileSystem.empty({ keyName, prerequisites })
+  fs = await FileSystem.empty({ keyName, permissions })
   await addSampleData(fs)
 
   // Fin

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -18,7 +18,7 @@ import * as ucanInternal from '../ucan/internal'
 
 import { AddResult, CID, FileContent } from '../ipfs'
 import { NoPermissionError } from '../errors'
-import { Prerequisites } from '../ucan/prerequisites'
+import { Permissions } from '../ucan/permissions'
 import { Ucan } from '../ucan'
 
 
@@ -36,13 +36,13 @@ type ConstructorParams = {
   mmpt: MMPT
   rootDid: string
 
-  prerequisites?: Prerequisites
+  permissions?: Permissions
 }
 
 type FileSystemOptions = {
   version?: SemVer
   keyName?: string
-  prerequisites?: Prerequisites
+  permissions?: Permissions
   rootDid?: string
 }
 
@@ -72,7 +72,7 @@ export class FileSystem implements UnixTree {
   syncWhenOnline: Array<[CID, string]>
 
 
-  constructor({ root, publicTree, prerequisites, prettyTree, privateTree, mmpt, rootDid }: ConstructorParams) {
+  constructor({ root, publicTree, permissions, prettyTree, privateTree, mmpt, rootDid }: ConstructorParams) {
     this.root = root
     this.publicTree = publicTree
     this.prettyTree = prettyTree
@@ -85,12 +85,12 @@ export class FileSystem implements UnixTree {
     this.syncWhenOnline = []
 
     if (
-      prerequisites &&
-      prerequisites.app &&
-      prerequisites.app.creator &&
-      prerequisites.app.name
+      permissions &&
+      permissions.app &&
+      permissions.app.creator &&
+      permissions.app.name
     ) {
-      this.appPath = appPath(prerequisites)
+      this.appPath = appPath(permissions)
     }
 
     // Add the root CID of the file system to the CID log
@@ -122,7 +122,7 @@ export class FileSystem implements UnixTree {
    * Creates a file system with an empty public tree & an empty private tree at the root.
    */
   static async empty(opts: FileSystemOptions = {}): Promise<FileSystem> {
-    const { keyName = 'filesystem-root', rootDid = '', prerequisites } = opts
+    const { keyName = 'filesystem-root', rootDid = '', permissions } = opts
 
     const publicTree = await PublicTree.empty()
     const prettyTree = await BareTree.empty()
@@ -136,7 +136,7 @@ export class FileSystem implements UnixTree {
     const fs = new FileSystem({
       root,
       publicTree,
-      prerequisites,
+      permissions,
       prettyTree,
       privateTree,
       mmpt,
@@ -158,7 +158,7 @@ export class FileSystem implements UnixTree {
    * Loads an existing file system from a CID.
    */
   static async fromCID(cid: CID, opts: FileSystemOptions = {}): Promise<FileSystem | null> {
-    const { keyName = 'filesystem-root', rootDid = '', prerequisites } = opts
+    const { keyName = 'filesystem-root', rootDid = '', permissions } = opts
 
     const root = await BareTree.fromCID(cid)
 
@@ -185,7 +185,7 @@ export class FileSystem implements UnixTree {
     const fs = new FileSystem({
       root,
       publicTree,
-      prerequisites,
+      permissions,
       prettyTree,
       privateTree,
       mmpt,
@@ -392,11 +392,11 @@ export default FileSystem
 // ㊙️
 
 
-function appPath(prerequisites: Prerequisites): ((path?: string | Array<string>) => string) {
+function appPath(permissions: Permissions): ((path?: string | Array<string>) => string) {
   return (path?: string | Array<string>): string => (
     'private/Apps/'
-      + (prerequisites.app ? prerequisites.app.creator + '/' : '')
-      + (prerequisites.app ? prerequisites.app.name : '')
+      + (permissions.app ? permissions.app.creator + '/' : '')
+      + (permissions.app ? permissions.app.name : '')
       + (path ? '/' + (typeof path == 'object' ? path.join('/') : path) : '')
   )
 }

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -284,14 +284,14 @@ export class FileSystem implements UnixTree {
   }
 
 
-  // PUBLICIZE
-  // ---------
+  // PUBLISH
+  // -------
 
   /**
    * Ensures the latest version of the file system is added to IPFS,
    * updates your data root, and returns the root CID.
    */
-  async publicise(): Promise<CID> {
+  async publish(): Promise<CID> {
     const proofs = Array.from(Object.entries(this.proofs))
     this.proofs = {}
 
@@ -303,13 +303,6 @@ export class FileSystem implements UnixTree {
     })
 
     return cid
-  }
-
-  /**
-   * Alias for `publicise`.
-   */
-  publicize(): Promise<CID> {
-    return this.publicise()
   }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,9 @@ export enum Scenario {
 }
 
 
+
 // STATE
+
 
 export type State
   = NotAuthorised

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ export * as keystore from './keystore'
 
 
 function scenarioAuthSucceeded(
-  permissions: Permissions
+  permissions: Permissions,
   newUser: boolean,
   username: string,
   fs: FileSystem | undefined
@@ -213,7 +213,7 @@ function scenarioAuthSucceeded(
 }
 
 function scenarioAuthCancelled(
-  permissions: Permissions
+  permissions: Permissions,
   cancellationReason: string
 ): AuthCancelled {
   return {
@@ -227,7 +227,7 @@ function scenarioAuthCancelled(
 }
 
 function scenarioContinuation(
-  permissions: Permissions
+  permissions: Permissions,
   username: string,
   fs: FileSystem | undefined
 ): Continuation {

--- a/src/ucan/internal.ts
+++ b/src/ucan/internal.ts
@@ -4,7 +4,7 @@ import * as common from '../common'
 import * as pathUtil from '../fs/path'
 import * as ucan from '../ucan'
 import { UCANS_STORAGE_KEY } from '../common'
-import { Prerequisites } from './prerequisites'
+import { Permissions } from './permissions'
 import { Ucan, WNFS_PREFIX } from '../ucan'
 import { setup } from '../setup/internal'
 
@@ -72,10 +72,10 @@ export async function store(ucans: Array<string>): Promise<void> {
 
 /**
  * See if the stored UCANs in the in-memory dictionary
- * conform to the given `Prerequisites`.
+ * conform to the given `Permissions`.
  */
-export function validatePrerequisites(
-  { app, fs }: Prerequisites,
+export function validatePermissions(
+  { app, fs }: Permissions,
   username: string
 ): boolean {
   const prefix = dictionaryFilesystemPrefix(username)
@@ -84,7 +84,7 @@ export function validatePrerequisites(
   const rootUcan = dictionary["*"]
   if (rootUcan && !ucan.isExpired(rootUcan)) return true
 
-  // Check prerequisites
+  // Check permissions
   if (app) {
     const u = dictionary[`${prefix}private/Apps/${app.creator}/${app.name}`]
     if (!u || ucan.isExpired(u)) return false

--- a/src/ucan/permissions.ts
+++ b/src/ucan/permissions.ts
@@ -1,6 +1,6 @@
-export type Prerequisites = {
+export type Permissions = {
   app?: AppInfo
-  fs?: FileSystemPrerequisites
+  fs?: FileSystemPermissions
 }
 
 export type AppInfo = {
@@ -8,7 +8,7 @@ export type AppInfo = {
   creator: string
 }
 
-export type FileSystemPrerequisites = {
+export type FileSystemPermissions = {
   privatePaths: Array<string>
   publicPaths: Array<string>
 }


### PR DESCRIPTION
I hinted at this in the API blog post I made: https://talk.fission.codes/t/user-facing-api/1013

I think that the return value for `initialize` can be simplified some.

I removed `prerequisites` & changed `scenario` to be an `enum` on `State`

Let me know what you think! I'm not married to this by any means, and you've been using this code in practice way more than I have, so I trust your judgement on it!