### PR TITLE
Return size on public dirs

### DIFF
--- a/src/fs/protocol/basic.ts
+++ b/src/fs/protocol/basic.ts
@@ -30,6 +30,7 @@ export const getLinks = async (cid: CID): Promise<Links> => {
     raw.map(link.fromFSFile)
   )
   // ipfs.ls does not return size, so we need to interpolate that in ourselves
+  // @@TODO: split into two functions: getLinks & getLinksDetailed. mtime & isFile are stored in our FS format in all but the pretty tree
   const dagNode = await ipfs.dagGet(cid)
   dagNode.Links.forEach((l) => {
     if(links[l.Name] && links[l.Name].size === 0){

--- a/src/fs/protocol/basic.ts
+++ b/src/fs/protocol/basic.ts
@@ -26,9 +26,17 @@ export const putEncryptedFile = async (content: FileContent, key: string): Promi
 
 export const getLinks = async (cid: CID): Promise<Links> => {
   const raw = await ipfs.ls(cid)
-  return link.arrToMap(
+  const links = link.arrToMap(
     raw.map(link.fromFSFile)
   )
+  // ipfs.ls does not return size, so we need to interpolate that in ourselves
+  const dagNode = await ipfs.dagGet(cid)
+  dagNode.Links.forEach((l) => {
+    if(links[l.Name] && links[l.Name].size === 0){
+      links[l.Name].size = l.Tsize
+    }
+  })
+  return links
 }
 
 export const putLinks = async (links: Links): Promise<AddResult> => {

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -20,24 +20,24 @@ export type DAGNode = {
 
 export type DAGLink = {
   Name: string
-  Hash: string
-  Size: number
+  Hash: CIDObj
+  Tsize: number
 }
 
 export type RawDAGNode = {
   remainderPath: string
   value: {
-    _data: Uint8Array
-    _links: RawDAGLink[]
+    Data: Uint8Array
+    Links: RawDAGLink[]
     _size: number
     _serializedSize: number
   }
 }
 
 export type RawDAGLink = {
-  _name: string
-  _cid: CIDObj
-  _size: number
+  Name: string
+  Hash: CIDObj
+  Tsize: number
 }
 
 export interface DagAPI {

--- a/src/ipfs/util.ts
+++ b/src/ipfs/util.ts
@@ -2,12 +2,12 @@ import dagPB from 'ipld-dag-pb'
 import { DAGNode, RawDAGNode, DAGLink, RawDAGLink } from './types'
 
 export const rawToDAGLink = (raw: RawDAGLink): DAGLink => {
-  return new dagPB.DAGLink(raw._name, raw._size, raw._cid)
+  return new dagPB.DAGLink(raw.Name, raw.Tsize, raw.Hash)
 }
 
 export const rawToDAGNode = (raw: RawDAGNode): DAGNode => {
-  const data = raw?.value?._data
-  const links = raw?.value?._links?.map(rawToDAGLink)
+  const data = raw?.value?.Data
+  const links = raw?.value?.Links?.map(rawToDAGLink)
   return new dagPB.DAGNode(data, links)
 }
 


### PR DESCRIPTION
## Problem
`ipfs.ls` does not return size for directories. I could've sworn that this worked in the past :thinking: but it doesn't return size in the in-browser daemon or a local go-ipfs node so this seems intentional

## Solution
Combine `ipfs.ls` output with `ipfs.dag.get` output to get the entire object that we're looking for