### PR TITLE
Decrypt read key from auth lobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "borc": "^2.1.1",
     "fission-bloom-filters": "^1.4.0",
     "ipld-dag-pb": "^0.18.2",
-    "keystore-idb": "^0.13.4",
+    "keystore-idb": "^0.13.5",
     "load-script2": "^2.0.5",
     "localforage": "^1.7.3",
     "make-error": "^1.3.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import localforage from 'localforage'
 
-import * as auth from './auth'
 import * as common from './common'
 import * as keystore from './keystore'
 import * as ucan from './ucan/internal'
@@ -113,10 +112,11 @@ export async function initialise(
   // Determine scenario
   if (ucans) {
     const newUser = url.searchParams.get("newUser") === "t"
-    const readKey = url.searchParams.get("readKey") || ""
+    const encryptedReadKey = url.searchParams.get("readKey") || ""
     const username = url.searchParams.get("username") || ""
 
     const ks = await keystore.get()
+    const readKey = await ks.decrypt(encryptedReadKey)
     await ks.importSymmKey(readKey, READ_KEY_FROM_LOBBY_NAME)
     await localforage.setItem(USERNAME_STORAGE_KEY, username)
 

--- a/src/keystore/config.ts
+++ b/src/keystore/config.ts
@@ -1,10 +1,11 @@
 import keystore from 'keystore-idb'
-import { KeyStore, CryptoSystem } from 'keystore-idb/types'
+import RSAKeyStore from 'keystore-idb/rsa/keystore'
+import { CryptoSystem } from 'keystore-idb/types'
 
 const KEYSTORE_CFG = { type: CryptoSystem.RSA }
 
 
-let ks: KeyStore | null = null
+let ks: RSAKeyStore | null = null
 
 
 export const clear = async (): Promise<void> => {
@@ -14,12 +15,12 @@ export const clear = async (): Promise<void> => {
   }
 }
 
-export const set = async (userKeystore: KeyStore): Promise<void> => {
+export const set = async (userKeystore: RSAKeyStore): Promise<void> => {
   ks = userKeystore
 }
 
-export const get = async (): Promise<KeyStore> => {
+export const get = async (): Promise<RSAKeyStore> => {
   if (ks) return ks
-  ks = await keystore.init(KEYSTORE_CFG)
+  ks = (await keystore.init(KEYSTORE_CFG)) as RSAKeyStore
   return ks
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2894,10 +2894,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keystore-idb@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.4.tgz#b2736ee183ce2767f93b59f61bbc7ad5fd20d6e2"
-  integrity sha512-jXYiTCebOUgz5qOwh9v3BoppUed3kNF9Xn55CZz3kmAKA3Ic0phB+Vx00yxnzlx6hQC0nce6txAi37TI046bZg==
+keystore-idb@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.13.5.tgz#978d2b240dbd68e80cef449eadb7ce2f30745a45"
+  integrity sha512-J/zHzZBlzomp/2AwrkWFlRew/Iub3wd6eKe9xLVmQpy2vG80cI9SoyB0KpVx8/DdlwEEedPdUIDXvlGWWQCWMA==
   dependencies:
     localforage "^1.7.3"
 


### PR DESCRIPTION
## Problem
Read key is being sent plaintext in query params when redirecting back to app

## Solution
- Encrypt with the app's exchange key & decrypt in the app
- `keystore.decrypt` was broken, so we need to upgrade `keystore-idb`

Relies on https://github.com/fission-suite/auth-lobby/pull/19