### PR TITLE
Race google & cloudflare lookups

### DIFF
--- a/src/common/async.ts
+++ b/src/common/async.ts
@@ -1,0 +1,9 @@
+/**
+ * Race an array of promises, returning whichever finishes first
+ */
+export function race <T>(promises: Promise<T>[]): Promise<T> {
+  return new Promise((resolve, reject) => {
+     for(const promise of promises)
+        promise.then(resolve, reject);
+  });
+}


### PR DESCRIPTION
## Problem
Cloudflare can intermittently be slow & unresponsive

## Solution
When doing DNS lookups, race Google & Cloudflare DNS-over-HTTPS and return the first to finish