### PR TITLE
Put files in MMPT & do file revisions properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -37,7 +37,10 @@ class BareTree extends BaseTree implements UnixTree {
     return new BareTree(links) 
   }
 
-  async createChildFile(content: FileContent): Promise<File> {
+  async createChildFile(content: FileContent, name: string): Promise<File> {
+    if(this.links[name]?.isFile === false) {
+      throw new Error(`There is already a directory with that name: ${name}`)
+    }
     return BareFile.create(content)
   }
 

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -85,7 +85,7 @@ abstract class BaseTree implements Tree, UnixTree {
       toAdd = await nextTree.addRecurse(nextPath, child)
     }
 
-    const toAddNode = check.isTree(toAdd) ? toAdd : await this.createChildFile(child as FileContent)
+    const toAddNode = check.isTree(toAdd) ? toAdd : await this.createChildFile(child as FileContent, name)
 
     return this.updateDirectChild(toAddNode, name)
   }
@@ -139,18 +139,18 @@ abstract class BaseTree implements Tree, UnixTree {
     return node !== null
   }
 
-  abstract async get(path: string): Promise<Tree | File | null>
+  abstract  get(path: string): Promise<Tree | File | null>
 
-  abstract async putDetailed(): Promise<AddResult>
-  abstract async updateDirectChild (child: Tree | File, name: string): Promise<this>
+  abstract  putDetailed(): Promise<AddResult>
+  abstract  updateDirectChild (child: Tree | File, name: string): Promise<this>
   abstract removeDirectChild(name: string): this
-  abstract async getDirectChild(name: string): Promise<Tree | File | null>
-  abstract async getOrCreateDirectChild(name: string): Promise<Tree | File>
+  abstract  getDirectChild(name: string): Promise<Tree | File | null>
+  abstract  getOrCreateDirectChild(name: string): Promise<Tree | File>
 
   abstract getLinks(): BaseLinks
 
-  abstract async emptyChildTree(): Promise<Tree>
-  abstract async createChildFile(content: FileContent): Promise<File>
+  abstract  emptyChildTree(): Promise<Tree>
+  abstract  createChildFile(content: FileContent, name: string): Promise<File>
 }
 
 

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -13,6 +13,15 @@ export const addNode = async (mmpt: MMPT, node: DecryptedNode, key: string): Pro
   const filter = await namefilter.addRevision(node.bareNameFilter, key, node.revision)
   const name = await namefilter.toPrivateName(filter)
   await mmpt.add(name, cid)
+
+  // if the node is a file, we also add the content to the MMPT
+  if(check.isPrivateFileInfo(node)) {
+    const contentBareFilter = await namefilter.addToBare(node.bareNameFilter, node.key)
+    const contentFilter = await namefilter.addRevision(contentBareFilter, node.key, node.revision)
+    const name = await namefilter.toPrivateName(contentFilter)
+    await mmpt.add(name, node.content)
+  }
+
   return { cid, name, key, size }
 }
 

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -18,8 +18,8 @@ export const addNode = async (mmpt: MMPT, node: DecryptedNode, key: string): Pro
   if(check.isPrivateFileInfo(node)) {
     const contentBareFilter = await namefilter.addToBare(node.bareNameFilter, node.key)
     const contentFilter = await namefilter.addRevision(contentBareFilter, node.key, node.revision)
-    const name = await namefilter.toPrivateName(contentFilter)
-    await mmpt.add(name, node.content)
+    const contentName = await namefilter.toPrivateName(contentFilter)
+    await mmpt.add(contentName, node.content)
   }
 
   return { cid, name, key, size }

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -74,7 +74,7 @@ export interface Tree extends UnixTree {
   getOrCreateDirectChild(name: string): Promise<Tree | File>
 
   emptyChildTree(): Promise<Tree>
-  createChildFile(content: FileContent): Promise<File>
+  createChildFile(content: FileContent, name: string): Promise<File>
 
   getLinks(): BaseLinks
 }

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -61,8 +61,7 @@ export class PrivateFile extends BaseFile implements File {
     if(!check.isPrivateFileInfo(info)) {
       throw new Error(`Could not parse a valid private tree using the given key`)
     }
-    const content = await protocol.basic.getEncryptedFile(info.content, info.key)
-    return new PrivateFile({ mmpt, key, info, content })
+    return PrivateFile.fromInfo(mmpt, key, info)
   }
 
   static async fromInfo(mmpt: MMPT, key: string, info: PrivateFileInfo): Promise<PrivateFile> {
@@ -76,8 +75,8 @@ export class PrivateFile extends BaseFile implements File {
   }
 
   async getName(): Promise<PrivateName> {
-    const { bareNameFilter, key, revision } = this.info
-    const revisionFilter = await namefilter.addRevision(bareNameFilter, key, revision)
+    const { bareNameFilter, revision } = this.info
+    const revisionFilter = await namefilter.addRevision(bareNameFilter, this.key, revision)
     return namefilter.toPrivateName(revisionFilter)
   }
 
@@ -100,7 +99,7 @@ export class PrivateFile extends BaseFile implements File {
     return protocol.priv.addNode(this.mmpt, {
       ...this.info, 
       metadata: metadata.updateMtime(this.info.metadata)
-    }, this.info.key)
+    }, this.key)
   }
 
 }

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -82,9 +82,18 @@ export default class PrivateTree extends BaseTree {
     return PrivateTree.create(this.mmpt, key, this.info.bareNameFilter)
   }
 
-  async createChildFile(content: FileContent): Promise<PrivateFile>{
-    const key = await genKeyStr()
-    return PrivateFile.create(this.mmpt, content, this.info.bareNameFilter, key)
+  async createChildFile(content: FileContent, name: string): Promise<PrivateFile>{
+    const existing = await this.getDirectChild(name)
+    let file: PrivateFile
+    if (existing === null) {
+      const key = await genKeyStr()
+      return PrivateFile.create(this.mmpt, content, this.info.bareNameFilter, key)
+    } else if (PrivateFile.instanceOf(existing)) {
+      file = await existing.updateContent(content)
+    } else {
+      throw new Error(`There is already a directory with that name: ${name}`)
+    }
+    return file
   }
 
   async putDetailed(): Promise<PrivateAddResult> {
@@ -163,7 +172,7 @@ export default class PrivateTree extends BaseTree {
     if(node === null) return null
       
     return check.isPrivateFileInfo(node)
-      ? PrivateFile.fromInfo(this.mmpt, node)
+      ? PrivateFile.fromInfo(this.mmpt, next.key, node)
       : PrivateTree.fromInfo(this.mmpt, next.key, node)
   }
 

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -61,7 +61,10 @@ export class PublicTree extends BaseTree {
     return PublicTree.empty()
   }
 
-  async createChildFile(content: FileContent): Promise<PublicFile> {
+  async createChildFile(content: FileContent, name: string): Promise<PublicFile> {
+    if(this.links[name]?.isFile === false) {
+      throw new Error(`There is already a directory with that name: ${name}`)
+    }
     return PublicFile.create(content)
   }
 


### PR DESCRIPTION
## Problem
Our IPFS Gateway is not grabbing all of the content needed for a user's FS. This is because file content is not being correctly added to the MMPT on the private side.

## Solution
- Put file contents in MMPT
- properly revision files & contents in MMPT

Also:
- add `members()` method to MMPT for debugging
- add `localOnly` flag for filesystem for local testing purposes