### PR TITLE
Hit fission server for dataroot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.0-alpha",
+  "version": "0.19.0-alpha2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -38,7 +38,7 @@ export async function lookupOnFisson(
   username: string
 ): Promise<CID | null> {
   try {
-    const resp = await fetch(`${setup.endpoints.api}/user/data/${username}`)
+    const resp = await fetch(`${setup.endpoints.api}/user/data/${username}`, { cache: 'reload' }) // don't use cache
     const cid = await resp.json()
     if (!check.isCID(cid)) {
       throw new Error("Did not receive a CID")


### PR DESCRIPTION
## Problem
DNS takes a while to propagate, and especially on initial lookups, it can take > 15 min

## Solution
Hit new server route for a user's DataRoot, if that fails, then go to DNS