### PR TITLE
Treat empty cid as null value

### DIFF
--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -59,7 +59,7 @@ export class PrivateFile extends BaseFile implements File {
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateFile> {
     const info = await protocol.priv.getByName(mmpt, name, key)
     if(!check.isPrivateFileInfo(info)) {
-      throw new Error(`Could not parse a valid private tree using the given key`)
+      throw new Error(`Could not parse a valid private file using the given key`)
     }
     return PrivateFile.fromInfo(mmpt, key, info)
   }


### PR DESCRIPTION
## Problem
We initially set a user's data root to a CID representing the empty string (to speed up DNS propagation). However the code expects a user's dataroot to be `null` when a filesystem does not exist. This initially wasn't an issue, because DNS wasn't fast enough to propagate the empty CID. But now that we retrieve DNS directly, we're trying to parse a filesystem object from an empty CID

## Solution
On DNS lookup, interpret the empty CID as `null`

Also added a debug statement & fixed the wording in an error