### PR TITLE
Reconnect before each operation

### DIFF
--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -71,6 +71,5 @@ export const size = async (cid: CID): Promise<number> => {
 }
 
 export const reconnect = async (): Promise<void> => {
-  const ipfs = await getIpfs()
-  await ipfs.swarm.connect(PEER_WSS)
+  await getIpfs()
 }

--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -33,17 +33,19 @@ export const set = (userIpfs: unknown): void => {
 }
 
 export const get = async (): Promise<IPFS> => {
-  if (ipfs) return ipfs
+  if (!ipfs) {
+    await loadScript(JS_IPFS)
 
-  await loadScript(JS_IPFS)
+    const Ipfs = await (window as IpfsWindow).Ipfs
+    if (!Ipfs) throw new Error(`Unable to load js-ipfs using the url: \`${JS_IPFS}\``)
 
-  const Ipfs = await (window as IpfsWindow).Ipfs
-  if (!Ipfs) throw new Error(`Unable to load js-ipfs using the url: \`${JS_IPFS}\``)
+    ipfs = await Ipfs.create({
+      ...defaultOptions,
+      ...setup.ipfs
+    })
+  }
 
-  ipfs = Ipfs.create({
-    ...defaultOptions,
-    ...setup.ipfs
-  })
+  await ipfs.swarm.connect(PEER_WSS)
 
   return ipfs
 }


### PR DESCRIPTION
## Problem
Our IPFS browser daemon can become disconnected from the remote node & then end up spinning it's wheels trying to grab content

## Solution
Reconnect before each operation. This is a _very_ lightweight operation