### PR TITLE
Do not recursively pin CIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.19.2
+
+Do not recursively pin content
+
 ### v0.19.1
 
 Permissions should be optional for `redirectToLobby` and `loadFileSystem` as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
-### v0.19.3
+### v0.19.4
 
-- Pin asynchronously
-- Don't error on failed pins
+Don't error on failed pins
 
 ### v0.19.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.19.3
+
+- Pin asynchronously
+- Don't error on failed pins
+
 ### v0.19.2
 
 Do not recursively pin content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -18,7 +18,7 @@ export const add = async (content: FileContent): Promise<AddResult> => {
 export const catRaw = async (cid: CID): Promise<Buffer[]> => {
   const ipfs = await getIpfs()
   const chunks = []
-  await ipfs.pin.add(cid, { recursive: false })
+  attemptPin(cid)
   for await (const chunk of ipfs.cat(cid)) {
     chunks.push(chunk)
   }
@@ -46,7 +46,7 @@ export const ls = async (cid: CID): Promise<UnixFSFile[]> => {
 
 export const dagGet = async (cid: CID): Promise<DAGNode> => {
   const ipfs = await getIpfs()
-  await ipfs.pin.add(cid, { recursive: false })
+  attemptPin(cid)
   const raw = await ipfs.dag.get(cid)
   return util.rawToDAGNode(raw)
 }
@@ -74,4 +74,13 @@ export const size = async (cid: CID): Promise<number> => {
 
 export const reconnect = async (): Promise<void> => {
   await getIpfs()
+}
+
+export const attemptPin = async (cid: CID): Promise<void> => {
+  const ipfs = await getIpfs()
+  try {
+    ipfs.pin.add(cid, { recursive: false })
+  }catch(_err) {
+    // don't worry about failed pins
+  }
 }

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -1,5 +1,5 @@
 import dagPB from 'ipld-dag-pb'
-import { get as getIpfs, PEER_WSS } from './config'
+import { get as getIpfs } from './config'
 import { CID, FileContent, DAGNode, UnixFSFile, DAGLink, AddResult } from './types'
 import util from './util'
 import { DAG_NODE_DATA } from './constants'
@@ -18,7 +18,7 @@ export const add = async (content: FileContent): Promise<AddResult> => {
 export const catRaw = async (cid: CID): Promise<Buffer[]> => {
   const ipfs = await getIpfs()
   const chunks = []
-  attemptPin(cid)
+  await attemptPin(cid)
   for await (const chunk of ipfs.cat(cid)) {
     chunks.push(chunk)
   }
@@ -46,7 +46,7 @@ export const ls = async (cid: CID): Promise<UnixFSFile[]> => {
 
 export const dagGet = async (cid: CID): Promise<DAGNode> => {
   const ipfs = await getIpfs()
-  attemptPin(cid)
+  await attemptPin(cid)
   const raw = await ipfs.dag.get(cid)
   return util.rawToDAGNode(raw)
 }

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -18,7 +18,7 @@ export const add = async (content: FileContent): Promise<AddResult> => {
 export const catRaw = async (cid: CID): Promise<Buffer[]> => {
   const ipfs = await getIpfs()
   const chunks = []
-  await ipfs.pin.add(cid)
+  await ipfs.pin.add(cid, { recursive: false })
   for await (const chunk of ipfs.cat(cid)) {
     chunks.push(chunk)
   }
@@ -46,7 +46,7 @@ export const ls = async (cid: CID): Promise<UnixFSFile[]> => {
 
 export const dagGet = async (cid: CID): Promise<DAGNode> => {
   const ipfs = await getIpfs()
-  await ipfs.pin.add(cid)
+  await ipfs.pin.add(cid, { recursive: false })
   const raw = await ipfs.dag.get(cid)
   return util.rawToDAGNode(raw)
 }

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -60,7 +60,7 @@ export interface ObjectAPI {
 }
 
 export interface PinAPI {
-  add(cid: CID | CIDObj): Promise<Array<CIDObj>>
+  add(cid: CID | CIDObj, opts?: { recursive?: boolean }): Promise<Array<CIDObj>>
 }
 
 export type CID = string


### PR DESCRIPTION
## Problem
Pinning is recursive by default
Since we pin any resource we `cat`/`ls`, we're downloading the entire FS on initial page load

## Solution
Change pins to non-recursive, so we only download what's necessary