### PR TITLE
Await on pin to catch error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.19.4
+### v0.19.5
 
 Don't error on failed pins
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -79,7 +79,7 @@ export const reconnect = async (): Promise<void> => {
 export const attemptPin = async (cid: CID): Promise<void> => {
   const ipfs = await getIpfs()
   try {
-    ipfs.pin.add(cid, { recursive: false })
+    await ipfs.pin.add(cid, { recursive: false })
   }catch(_err) {
     // don't worry about failed pins
   }


### PR DESCRIPTION
## Problem
We're pinning async, so the error isn't being caught

## Solution
`await` on pin