### PR TITLE
Fix type check for public tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.19.6
+
+Bugfix: changes to public tree were not being reflected in pretty tree
+
 ### v0.19.5
 
 Don't error on failed pins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -340,7 +340,11 @@ export class FileSystem implements UnixTree {
     if (head === 'public') {
       result = await fn(this.publicTree, relPath)
 
+      console.log("HERE: ", isMutation)
+      console.log("HERE: ", PublicTree.instanceOf(result))
+
       if (isMutation && PublicTree.instanceOf(result)) {
+        console.log("RUNNING ON PRETTY")
         resultPretty = await fn(this.prettyTree, relPath)
 
         this.publicTree = result

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -340,11 +340,7 @@ export class FileSystem implements UnixTree {
     if (head === 'public') {
       result = await fn(this.publicTree, relPath)
 
-      console.log("HERE: ", isMutation)
-      console.log("HERE: ", PublicTree.instanceOf(result))
-
       if (isMutation && PublicTree.instanceOf(result)) {
-        console.log("RUNNING ON PRETTY")
         resultPretty = await fn(this.prettyTree, relPath)
 
         this.publicTree = result

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -4,7 +4,7 @@
 import { isString, isObject, isNum, isBool } from '../../common'
 import { CID } from '../../ipfs'
 import { Tree, File, Link, Links, BaseLink } from '../types'
-import { Skeleton, TreeInfo, FileInfo } from '../protocol/public/types'
+import { Skeleton, TreeInfo, FileInfo, TreeHeader } from '../protocol/public/types'
 import { SemVer } from '../semver'
 import { Metadata, UnixMeta } from '../metadata'
 
@@ -60,12 +60,16 @@ export const isSkeleton = (obj: any): obj is Skeleton => {
       ))
 }
 
-export const isTreeInfo = (obj: any): obj is TreeInfo => {
+export const isTreeHeader = (obj: any): obj is TreeHeader => {
   return isObject(obj)
-    && isCID(obj.userland)
     && isSkeleton(obj.skeleton)
     && isMetadata(obj.metadata)
     && obj.metadata.isFile === false
+}
+
+export const isTreeInfo = (obj: any): obj is TreeInfo => {
+  return isTreeHeader(obj)
+    && isCID((obj as any).userland)
 }
 
 export const isFileInfo = (obj: any): obj is FileInfo => {


### PR DESCRIPTION
## Problem
Public write methods aren't getting run on the `pretty` tree. This is because the `PublicTree.instanceOf` method is not formatted correctly.

## Solution
Update `PublicTree.instanceof` to correctly identify public trees. Also update the user of `info`/`header` to be more consistent