### PR TITLE
Bugfix: Public tree update files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.19.7
+
+Bugfix: updates to files on public side were failing
+
 ### v0.19.6
 
 Bugfix: changes to public tree were not being reflected in pretty tree

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -62,7 +62,7 @@ export class PublicTree extends BaseTree {
   }
 
   async createChildFile(content: FileContent, name: string): Promise<PublicFile> {
-    if(this.links[name]?.isFile === false) {
+    if(this.header.skeleton[name]?.isFile === false) {
       throw new Error(`There is already a directory with that name: ${name}`)
     }
     return PublicFile.create(content)


### PR DESCRIPTION
## Problem
Updating files on the public tree fails because we incorrectly identity files as directories. This is because files _are_ directories at the protocol level, but _not_ at the platform level 

## Solution
Check if a given node is a file in the node's skeleton (the platform-level description) instead of the node's links (the protocol level description)
