### PR TITLE
Concurrent FS operations & basic versioning

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,8 @@
   cp -r ./docs dist/
 
 @publish:
+  # TODO: Auto detect what to do based on version in package.json
+  #       if alpha version, publish alpha, otherwise latest
   just publish-latest
 
 @publish-latest:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-5",
+  "version": "0.20.0-alpha-8",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.12",
+  "version": "0.20.0-alpha-2",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-4",
+  "version": "0.20.0-alpha-5",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-8",
+  "version": "0.20.0-alpha-9",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-9",
+  "version": "0.20.0-alpha-10",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-10",
+  "version": "0.20.0",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-2",
+  "version": "0.20.0-alpha-3",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "webnative",
   "version": "0.20.0",
-  "description": "Fission Typescript SDK",
-  "keywords": [],
+  "description": "Fission Webnative SDK",
+  "keywords": ["WebCrypto", "auth", "IPFS", "files"],
   "main": "index.cjs.js",
   "module": "index.es5.js",
   "browser": "index.umd.js",
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/fission-suite/webnative"
   },
+  "homepage": "https://guide.fission.codes",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=10.21.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.20.0-alpha-3",
+  "version": "0.20.0-alpha-4",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/fs/bare/file.ts
+++ b/src/fs/bare/file.ts
@@ -1,6 +1,7 @@
 import { AddResult, CID, FileContent } from '../../ipfs'
 import * as protocol from '../protocol'
 import BaseFile from '../base/file'
+import { isObject } from '../../common'
 
 
 export class BareFile extends BaseFile {
@@ -12,6 +13,10 @@ export class BareFile extends BaseFile {
   static async fromCID(cid: CID): Promise<BareFile> {
     const content = await protocol.basic.getFile(cid)
     return new BareFile(content)
+  }
+
+  static instanceOf (obj: any): obj is BareFile {
+    return isObject(obj) && obj.content !== undefined
   }
 
   async put(): Promise<CID> {

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -34,8 +34,17 @@ class BareTree extends BaseTree {
     return new BareTree(links) 
   }
 
-  async createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<BareTree> {
+  async createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree> {
     const child = await BareTree.empty()
+
+    const existing = this.children[name]
+    if(existing) {
+      if(BareFile.instanceOf(existing)) {
+        throw new Error(`There is a file at the given path: ${name}`)
+      }
+      return existing
+    }
+
     await this.updateDirectChild(child, name, onUpdate)
     return child
   }

--- a/src/fs/bare/tree.ts
+++ b/src/fs/bare/tree.ts
@@ -1,5 +1,5 @@
 import * as protocol from '../protocol'
-import { Links, Tree, File, Link, SyncHookDetailed, UnixTree, BaseLinks } from '../types'
+import { Links, BaseLinks, Tree, File, Puttable, UpdateCallback } from '../types'
 import * as check from '../types/check'
 import { AddResult, CID, FileContent } from '../../ipfs'
 import BareFile from '../bare/file'
@@ -10,14 +10,15 @@ import * as pathUtil from '../path'
 import { Maybe } from '../../common'
 
 
-class BareTree extends BaseTree implements UnixTree {
+class BareTree extends BaseTree {
 
   links: Links
-  onUpdate: Maybe<SyncHookDetailed> = null
+  children: { [name: string]: Tree | File }
 
   constructor(links: Links) {
     super(semver.v0)
     this.links = links
+    this.children = {}
   }
 
   static async empty(): Promise<BareTree> {
@@ -29,52 +30,72 @@ class BareTree extends BaseTree implements UnixTree {
     return new BareTree(links) 
   }
 
-  async emptyChildTree(): Promise<BareTree> {
-    return BareTree.empty()
-  }
-
   static fromLinks(links: Links): BareTree {
     return new BareTree(links) 
   }
 
-  async createChildFile(content: FileContent, name: string): Promise<File> {
-    if(this.links[name]?.isFile === false) {
+  async createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<BareTree> {
+    const child = await BareTree.empty()
+    await this.updateDirectChild(child, name, onUpdate)
+    return child
+  }
+
+  async createOrUpdateChildFile(content: FileContent, name: string, onUpdate: Maybe<UpdateCallback>): Promise<BareFile> {
+    const existing = await this.getDirectChild(name)
+    let file: BareFile
+    if(existing === null){
+      file = await BareFile.create(content)
+    } else if (BareFile.instanceOf(existing)) {
+      file = await existing.updateContent(content)
+    }else {
       throw new Error(`There is already a directory with that name: ${name}`)
     }
-    return BareFile.create(content)
+    await this.updateDirectChild(file, name, onUpdate)
+    return file
   }
 
   async putDetailed(): Promise<AddResult> {
-    const details = await protocol.basic.putLinks(this.links)
-    if(this.onUpdate !== null){
-      this.onUpdate(details)
-    }
-    return details
+    return protocol.basic.putLinks(this.links)
   }
 
-  async updateDirectChild(child: Tree | File, name: string): Promise<this> {
-    const { cid, size } = await child.putDetailed()
-    const childLink = link.make(name, cid, check.isFile(child), size)
-    this.links[childLink.name] = childLink
+  async putAndUpdateLink(child: Puttable, name: string, onUpdate: Maybe<UpdateCallback>): Promise<this> {
+    const details = await child.putDetailed()
+    this.updateLink(name, details)
+    onUpdate && await onUpdate()
     return this
+  }
+
+  async updateDirectChild(child: Tree | File, name: string, onUpdate: Maybe<UpdateCallback>): Promise<this> {
+    this.children[name] = child
+    return this.putAndUpdateLink(child, name, onUpdate)
   }
 
   removeDirectChild(name: string): this {
     delete this.links[name]
+    if(this.children[name]) {
+      delete this.children[name]
+    }
     return this
   }
 
   async getDirectChild(name: string): Promise<Tree | File | null> {
+    if(this.children[name]) {
+      return this.children[name]
+    }
+
     const link = this.links[name] || null
     if(link === null) return null
-    return link.isFile
-          ? BareFile.fromCID(link.cid)
-          : BareTree.fromCID(link.cid)
-  }
+    const child = link.isFile
+      ? await BareFile.fromCID(link.cid)
+      : await BareTree.fromCID(link.cid)
 
-  async getOrCreateDirectChild(name: string): Promise<Tree | File> {
-    const child = await this.getDirectChild(name)
-    return child ? child : this.emptyChildTree()
+    // check that the child wasn't added while retrieving the content from the network
+    if(this.children[name]) {
+      return this.children[name]
+    }
+
+    this.children[name] = child
+    return child
   }
 
   async get(path: string): Promise<Tree | File | null> {
@@ -91,11 +112,9 @@ class BareTree extends BaseTree implements UnixTree {
     return nextTree.get(nextPath)
   }
 
-  updateLink(link: Link): Tree {
-    this.links = {
-      ...this.links,
-      [link.name]: link
-    }
+  updateLink(name: string, result: AddResult): this {
+    const { cid, size, isFile } = result
+    this.links[name] = link.make(name, cid, isFile, size)
     return this
   }
 

--- a/src/fs/base/file.ts
+++ b/src/fs/base/file.ts
@@ -18,7 +18,12 @@ export abstract class BaseFile implements File {
     return cid
   }
 
-  abstract async putDetailed(): Promise<AddResult>
+  async updateContent(content: FileContent): Promise<this> {
+    this.content = content
+    return this
+  }
+
+  abstract putDetailed(): Promise<AddResult>
 }
 
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -1,6 +1,6 @@
 import { throttle } from 'throttle-debounce'
 
-import { PublishHook, UnixTree, Tree, File, BaseLinks, UpdateProof } from './types'
+import { PublishHook, UnixTree, Tree, File, BaseLinks } from './types'
 import { SemVer } from './semver'
 import BareTree from './bare/tree'
 import MMPT from './protocol/private/mmpt'
@@ -47,6 +47,10 @@ type FileSystemOptions = {
   localOnly?: boolean
 }
 
+type MutationOptions = {
+  publish?: boolean
+}
+
 enum Branch {
   Public = 'public',
   Pretty = 'pretty',
@@ -54,11 +58,10 @@ enum Branch {
 }
 
 
-
 // CLASS
 
 
-export class FileSystem implements UnixTree {
+export class FileSystem {
 
   root: BareTree
   publicTree: PublicTree
@@ -216,10 +219,13 @@ export class FileSystem implements UnixTree {
   // POSIX INTERFACE
   // ---------------
 
-  async mkdir(path: string): Promise<this> {
+  async mkdir(path: string, options: MutationOptions = {}): Promise<this> {
     await this.runOnTree(path, true, (tree, relPath) => {
       return tree.mkdir(relPath)
     })
+    if(options.publish) {
+      await this.publish()
+    }
     return this
   }
 
@@ -229,10 +235,13 @@ export class FileSystem implements UnixTree {
     })
   }
 
-  async add(path: string, content: FileContent): Promise<this> {
+  async add(path: string, content: FileContent, options: MutationOptions = {}): Promise<this> {
     await this.runOnTree(path, true, (tree, relPath) => {
       return tree.add(relPath, content)
     })
+    if(options.publish) {
+      await this.publish()
+    }
     return this
   }
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -294,8 +294,9 @@ export class FileSystem {
 
       if (isMutation && PrivateTree.instanceOf(result)) {
         this.root.privateTree = result
-        await this.root.privateTree.put()
+        const cid = await this.root.privateTree.put()
         await this.root.updatePuttable(Branch.Private, this.root.mmpt)
+        await this.root.addPrivateLogEntry(cid)
       }
 
     } else if (head === Branch.Pretty && isMutation) {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -287,8 +287,8 @@ export class FileSystem {
     return this.cat(path)
   }
 
-  async write(path: string, content: FileContent): Promise<this> {
-    return this.add(path, content)
+  async write(path: string, content: FileContent, options: MutationOptions = {}): Promise<this> {
+    return this.add(path, content, options)
   }
 
 

--- a/src/fs/link.ts
+++ b/src/fs/link.ts
@@ -1,10 +1,10 @@
 import dagPB from 'ipld-dag-pb'
 
 import { DAGLink, UnixFSFile } from '../ipfs'
-import { Link, Links } from './types'
+import { Link, SimpleLink } from './types'
 
 
-export const toDAGLink = (link: Link): DAGLink => {
+export const toDAGLink = (link: SimpleLink): DAGLink => {
   const { name, cid, size } = link
   return new dagPB.DAGLink(name, size, cid)
 }
@@ -20,6 +20,13 @@ export const fromFSFile = (fsObj: UnixFSFile): Link => {
   }
 }
 
+export const fromDAGLink = (link: DAGLink): SimpleLink => {
+  const name = link.Name
+  const cid = link.Hash.toString()
+  const size = link.Tsize
+  return { name, cid, size }
+}
+
 export const make = (name: string, cid: string, isFile: boolean, size: number): Link => {
   return {
     name,
@@ -30,9 +37,11 @@ export const make = (name: string, cid: string, isFile: boolean, size: number): 
   }
 }
 
-export const arrToMap = (arr: Link[]): Links => {
+type HasName = { name: string }
+
+export const arrToMap = <T extends HasName>(arr: T[]): { [name: string]: T } => {
   return arr.reduce((acc, cur) => {
     acc[cur.name] = cur
     return acc
-  }, {} as Links)
+  }, {} as { [name: string]: T})
 }

--- a/src/fs/path.ts
+++ b/src/fs/path.ts
@@ -27,7 +27,20 @@ export const takeHead = (path: string): HeadParts => {
     head: parts[0] || null,
     nextPath: next.length > 0 ? join(next) : null
   }
+}
 
+type TailParts = {
+  tail: string | null
+  parentPath: string | null
+}
+
+export const takeTail = (path: string): TailParts => {
+  const parts = splitParts(path)
+  const parent = parts.slice(0, parts.length - 1)
+  return {
+    tail: parts[parts.length - 1] || null,
+    parentPath: parent.length > 0 ? join(parent) : null
+  }
 }
 
 export const splitNonEmpty = (path: string): NonEmptyPath | null => {

--- a/src/fs/protocol/basic.ts
+++ b/src/fs/protocol/basic.ts
@@ -4,7 +4,7 @@
 import * as ipfs from '../../ipfs'
 import { CID, FileContent, AddResult } from '../../ipfs'
 
-import { Links } from '../types'
+import { SimpleLinks, Links } from '../types'
 import * as link from '../link'
 
 
@@ -24,6 +24,13 @@ export const putEncryptedFile = async (content: FileContent, key: string): Promi
   return ipfs.encoded.add(content, key)
 }
 
+export const getSimpleLinks = async (cid: CID): Promise<SimpleLinks> => {
+  const dagNode = await ipfs.dagGet(cid)
+  return link.arrToMap(
+    dagNode.Links.map(link.fromDAGLink)
+  )
+}
+
 export const getLinks = async (cid: CID): Promise<Links> => {
   const raw = await ipfs.ls(cid)
   const links = link.arrToMap(
@@ -40,7 +47,9 @@ export const getLinks = async (cid: CID): Promise<Links> => {
   return links
 }
 
-export const putLinks = async (links: Links): Promise<AddResult> => {
-  const dagLinks = Object.values(links).map(link.toDAGLink)
+export const putLinks = async (links: Links | SimpleLinks): Promise<AddResult> => {
+  const dagLinks = Object.values(links)
+    .filter(l => l !== undefined)
+    .map(link.toDAGLink)
   return ipfs.dagPutLinks(dagLinks)
 }

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -38,14 +38,18 @@ export const readNode = async (cid: CID, key: string): Promise<DecryptedNode> =>
 /**
  * Retrieve a private file/tree from the MMPT.
  */
-export const getByName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
+export const getLatestByName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
   const cid = await mmpt.get(name)
   if (cid === null) return null
-  return getByCID(mmpt, cid, key)
+  return getLatestByCID(mmpt, cid, key)
 }
 
-export const getByCID = async (mmpt: MMPT, cid: CID, key: string): Promise<DecryptedNode> => {
-  return readNode(cid, key)
+export const getLatestByCID = async (mmpt: MMPT, cid: CID, key: string): Promise<DecryptedNode> => {
+  const node = await readNode(cid, key)
+  const latest = await findLatestRevision(mmpt, node.bareNameFilter, key, node.revision)
+  return latest?.cid
+    ? readNode(latest?.cid, key)
+    : node
 }
 
 export const findLatestRevision = async (mmpt: MMPT, bareName: BareNameFilter, key: string, lastKnownRevision: number): Promise<Maybe<Revision>> => {

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -22,7 +22,8 @@ export const addNode = async (mmpt: MMPT, node: DecryptedNode, key: string): Pro
     await mmpt.add(contentName, node.content)
   }
 
-  return { cid, name, key, size }
+  const [skeleton, isFile] = check.isPrivateFileInfo(node) ? [{}, true] : [node.skeleton, false]
+  return { cid, name, key, size, isFile, skeleton }
 }
 
 export const readNode = async (cid: CID, key: string): Promise<DecryptedNode> => {

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -35,20 +35,27 @@ export const readNode = async (cid: CID, key: string): Promise<DecryptedNode> =>
   return content
 }
 
-/**
- * Retrieve a private file/tree from the MMPT.
- */
-export const getLatestByName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
+export const getByName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
+  const cid = await mmpt.get(name)
+  if (cid === null) return null
+  return getByCID(cid, key)
+}
+
+export const getByCID = async (cid: CID, key: string): Promise<DecryptedNode> => {
+  return await readNode(cid, key)
+}
+
+export const getByLatestName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
   const cid = await mmpt.get(name)
   if (cid === null) return null
   return getLatestByCID(mmpt, cid, key)
 }
 
 export const getLatestByCID = async (mmpt: MMPT, cid: CID, key: string): Promise<DecryptedNode> => {
-  const node = await readNode(cid, key)
+  const node = await getByCID(cid, key)
   const latest = await findLatestRevision(mmpt, node.bareNameFilter, key, node.revision)
   return latest?.cid
-    ? readNode(latest?.cid, key)
+    ? await getByCID(latest?.cid, key)
     : node
 }
 

--- a/src/fs/protocol/private/namefilter.ts
+++ b/src/fs/protocol/private/namefilter.ts
@@ -26,7 +26,7 @@ export type SaturatedNameFilter = Opaque<"SaturatedNameFilter", string>
 
 
 
-// FUNCTIONS  
+// FUNCTIONS
 
 // create bare name filter with a single key
 export const createBare = async (key: string): Promise<BareNameFilter> => {
@@ -47,7 +47,7 @@ export const addRevision = async (bareFilter: BareNameFilter, key: string, revis
   return (await addToBare(bareFilter, revision + key)) as string as RevisionNameFilter
 }
 
-// saturate the filter to 320 bits and hash it with sha256 to give the pirvate name that a node will be stored in the MMPT with
+// saturate the filter to 320 bits and hash it with sha256 to give the private name that a node will be stored in the MMPT with
 export const toPrivateName = async (revisionFilter: RevisionNameFilter): Promise<PrivateName> => {
   const saturated = await saturateFilter(fromHex(revisionFilter))
   return toHash(saturated)

--- a/src/fs/protocol/private/namefilter.ts
+++ b/src/fs/protocol/private/namefilter.ts
@@ -44,7 +44,7 @@ export const addToBare = async (bareFilter: BareNameFilter, toAdd: string): Prom
 
 // add the revision number to the name filter, salted with the AES key for the node
 export const addRevision = async (bareFilter: BareNameFilter, key: string, revision: number): Promise<RevisionNameFilter> => {
-  return (await addToBare(bareFilter, revision + key)) as string as RevisionNameFilter
+  return (await addToBare(bareFilter, `${revision}${key}`)) as string as RevisionNameFilter
 }
 
 // saturate the filter to 320 bits and hash it with sha256 to give the private name that a node will be stored in the MMPT with

--- a/src/fs/protocol/private/types.ts
+++ b/src/fs/protocol/private/types.ts
@@ -39,4 +39,5 @@ export type PrivateSkeletonInfo = {
 export type PrivateAddResult = AddResult & {
   name: PrivateName
   key: string
+  skeleton: PrivateSkeleton
 }

--- a/src/fs/protocol/private/types.ts
+++ b/src/fs/protocol/private/types.ts
@@ -13,7 +13,7 @@ export type PrivateFileInfo = {
   key: string
 }
 
-export type PrivateLink = BaseLink & { 
+export type PrivateLink = BaseLink & {
   key: string
   pointer: PrivateName
 }
@@ -24,7 +24,7 @@ export type PrivateTreeInfo = {
   metadata: Metadata
   bareNameFilter: BareNameFilter
   revision: number
-  links: PrivateLinks 
+  links: PrivateLinks
   skeleton: PrivateSkeleton
 }
 
@@ -40,4 +40,10 @@ export type PrivateAddResult = AddResult & {
   name: PrivateName
   key: string
   skeleton: PrivateSkeleton
+}
+
+export type Revision = {
+  cid: CID
+  name: PrivateName,
+  number: number
 }

--- a/src/fs/protocol/public/index.ts
+++ b/src/fs/protocol/public/index.ts
@@ -26,14 +26,14 @@ export const putTree = async (
     putAndMakeLink('metadata', metadataVal),
     putAndMakeLink('skeleton', skeletonVal),
   ])
-  const previous = previousCID !== null 
+  const previous = previousCID != null
     ? link.make('previous', previousCID, false, await ipfs.size(previousCID))
     : undefined
 
   const internalLinks = { metadata, skeleton, userland, previous } as Links
   const { cid, size } = await basic.putLinks(internalLinks)
-  return { 
-    cid, 
+  return {
+    cid,
     userland: userland.cid,
     metadata: metadata.cid,
     size,
@@ -50,13 +50,13 @@ export const putFile = async (
   const userlandInfo = await basic.putFile(content)
   const userland = link.make('userland', userlandInfo.cid, true, userlandInfo.size)
   const metadata = await putAndMakeLink('metadata', metadataVal)
-  const previous = previousCID !== null 
+  const previous = previousCID != null
     ? link.make('previous', previousCID, false, await ipfs.size(previousCID))
     : undefined
 
   const internalLinks = { metadata, userland, previous } as Links
   const { cid, size } = await basic.putLinks(internalLinks)
-  return { 
+  return {
     cid,
     userland: userland.cid,
     metadata: metadata.cid,
@@ -74,14 +74,15 @@ export const putAndMakeLink = async (name: string, val: FileContent) => {
 export const get = async (cid: CID): Promise<TreeInfo | FileInfo> => {
   const links = await basic.getLinks(cid)
   const metadata = await getAndCheckValue(links, 'metadata', check.isMetadata)
-  const skeleton = metadata.isFile 
+  const skeleton = metadata.isFile
     ? undefined
     : await getAndCheckValue(links, 'skeleton', check.isSkeleton)
 
   const userland = links['userland']?.cid || null
-  if(!check.isCID(userland)) throw new Error("Could not find userland")
+  if (!check.isCID(userland)) throw new Error("Could not find userland")
 
-  return { userland, metadata, skeleton }
+  const previous = links['previous']?.cid || undefined
+  return { userland, metadata, previous, skeleton }
 }
 
 export const getValue = async (

--- a/src/fs/protocol/public/index.ts
+++ b/src/fs/protocol/public/index.ts
@@ -1,13 +1,13 @@
 /** @internal */
 
 /** @internal */
-import { Links, PutDetails } from '../../types'
-import { TreeInfo, FileInfo, Skeleton } from './types'
+import { Links } from '../../types'
+import { TreeInfo, FileInfo, Skeleton, PutDetails } from './types'
 import { Metadata } from '../../metadata'
 import { isString } from '../../../common/type-checks'
 import * as check from '../../types/check'
 
-import { isValue } from '../../../common'
+import { isValue, Maybe } from '../../../common'
 import * as ipfs from '../../../ipfs'
 import { CID, FileContent } from '../../../ipfs'
 import * as link from '../../link'
@@ -17,7 +17,8 @@ import * as basic from '../basic'
 export const putTree = async (
     links: Links,
     skeletonVal: Skeleton,
-    metadataVal: Metadata
+    metadataVal: Metadata,
+    previousCID: Maybe<CID>
   ): Promise<PutDetails> => {
   const userlandInfo = await basic.putLinks(links)
   const userland = link.make('userland', userlandInfo.cid, true, userlandInfo.size)
@@ -25,21 +26,44 @@ export const putTree = async (
     putAndMakeLink('metadata', metadataVal),
     putAndMakeLink('skeleton', skeletonVal),
   ])
-  const internalLinks = { metadata, skeleton, userland } as Links
+  const previous = previousCID !== null 
+    ? link.make('previous', previousCID, false, await ipfs.size(previousCID))
+    : undefined
+
+  const internalLinks = { metadata, skeleton, userland, previous } as Links
   const { cid, size } = await basic.putLinks(internalLinks)
-  return { cid, userland: userland.cid, metadata: metadata.cid, size }
+  return { 
+    cid, 
+    userland: userland.cid,
+    metadata: metadata.cid,
+    size,
+    isFile: false,
+    skeleton: skeletonVal
+  }
 }
 
 export const putFile = async (
     content: FileContent,
-    metadataVal: Metadata
+    metadataVal: Metadata,
+    previousCID: Maybe<CID>
   ): Promise<PutDetails> => {
   const userlandInfo = await basic.putFile(content)
   const userland = link.make('userland', userlandInfo.cid, true, userlandInfo.size)
   const metadata = await putAndMakeLink('metadata', metadataVal)
-  const internalLinks = { metadata, userland } as Links
+  const previous = previousCID !== null 
+    ? link.make('previous', previousCID, false, await ipfs.size(previousCID))
+    : undefined
+
+  const internalLinks = { metadata, userland, previous } as Links
   const { cid, size } = await basic.putLinks(internalLinks)
-  return { cid, userland: userland.cid, metadata: metadata.cid, size }
+  return { 
+    cid,
+    userland: userland.cid,
+    metadata: metadata.cid,
+    size,
+    isFile: true,
+    skeleton: {}
+  }
 }
 
 export const putAndMakeLink = async (name: string, val: FileContent) => {

--- a/src/fs/protocol/public/types.ts
+++ b/src/fs/protocol/public/types.ts
@@ -1,5 +1,12 @@
 import { Metadata } from '../../metadata'
-import { CID } from '../../../ipfs'
+import { AddResult, CID } from '../../../ipfs'
+
+export type PutDetails = AddResult & {
+  userland: CID
+  metadata: CID
+  isFile: boolean
+  skeleton: Skeleton
+}
 
 export type SkeletonInfo = {
   cid: CID

--- a/src/fs/protocol/public/types.ts
+++ b/src/fs/protocol/public/types.ts
@@ -20,6 +20,7 @@ export type Skeleton = { [name: string]: SkeletonInfo }
 
 export type TreeHeader = {
   metadata: Metadata
+  previous?: CID
   skeleton: Skeleton
 }
 
@@ -29,9 +30,9 @@ export type TreeInfo = TreeHeader & {
 
 export type FileHeader = {
   metadata: Metadata
+  previous?: CID
 }
 
 export type FileInfo = FileHeader & {
   userland: CID
 }
-

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -1,6 +1,8 @@
 import { Branch, Links, Puttable } from '../types'
 import { AddResult, CID } from '../../ipfs'
 import { SemVer } from '../semver'
+import { sha256Str } from '../../keystore'
+import * as ipfs from '../../ipfs'
 import * as link from '../link'
 import * as protocol from '../protocol'
 import * as semver from '../semver'
@@ -122,11 +124,6 @@ export default class RootTree implements Puttable {
     return protocol.basic.putLinks(this.links)
   }
 
-  async setVersion(version: SemVer): Promise<this> {
-    const result = await protocol.basic.putFile(semver.toString(version))
-    return this.updateLink("version", result)
-  }
-
   updateLink(name: string, result: AddResult): this {
     const { cid, size, isFile } = result
     this.links[name] = link.make(name, cid, isFile, size)
@@ -135,6 +132,90 @@ export default class RootTree implements Puttable {
 
   async updatePuttable(name: string, puttable: Puttable): Promise<this> {
     return this.updateLink(name, await puttable.putDetailed())
+  }
+
+
+  // PRIVATE LOG
+  // -----------
+  //
+  // {
+  //   "currentChunkIndex": 2,
+  //   "0": first_log,
+  //   "1": second_log,
+  //   "2": current_log
+  // }
+  //
+  // Chunk size is based on the default IPFS block size,
+  // which is 1024 * 256 bytes. 1 log chunk should fit in 1 block.
+  // We'll use the CSV format for the data in the chunks.
+  static LOG_CHUNK_SIZE = 1020 // Math.floor((1024 * 256) / (256 + 1))
+
+
+  async addPrivateLogEntry(cid: string): Promise<void> {
+    const logCid = this.links[Branch.PrivateLog]?.cid
+    const log = logCid ? await protocol.basic.getSimpleLinks(logCid) : {}
+
+    // current chunk index
+    let currentChunkIndex = log.currentChunkIndex?.cid
+      ? JSON.parse(await ipfs.cat(log.currentChunkIndex?.cid)) || 0
+      : 0
+
+    // get current chunk
+    let currentChunk = log[currentChunkIndex]?.cid
+      ? (await ipfs.cat(log[currentChunkIndex]?.cid)).split(",")
+      : []
+
+    // needs new chunk
+    const needsNewChunk = currentChunk.length + 1 > RootTree.LOG_CHUNK_SIZE
+
+    if (needsNewChunk) {
+      currentChunkIndex = currentChunkIndex + 1
+      currentChunk = []
+    }
+
+    if (needsNewChunk || !log.currentChunkIndex) {
+      const currentChunkIndexDeposit = await protocol.basic.putFile(
+        JSON.stringify(currentChunkIndex)
+      )
+
+      const currentChunkIndexLink = link.make(
+        "currentChunkIndex",
+        currentChunkIndexDeposit.cid,
+        currentChunkIndexDeposit.isFile,
+        currentChunkIndexDeposit.size
+      )
+
+      log.currentChunkIndex = currentChunkIndexLink
+    }
+
+    // add to chunk
+    const hashedCid = await sha256Str(cid)
+    const updatedChunk = [...currentChunk, hashedCid]
+    const updatedChunkDeposit = await protocol.basic.putFile(
+      updatedChunk.join(",")
+    )
+
+    const updatedChunkLink = link.make(
+      currentChunkIndex.toString(),
+      updatedChunkDeposit.cid,
+      updatedChunkDeposit.isFile,
+      updatedChunkDeposit.size
+    )
+
+    log[currentChunkIndex.toString()] = updatedChunkLink
+
+    // save log
+    const logDeposit = await protocol.basic.putLinks(log)
+    this.updateLink(Branch.PrivateLog, logDeposit)
+  }
+
+
+  // VERSION
+  // -------
+
+  async setVersion(version: SemVer): Promise<this> {
+    const result = await protocol.basic.putFile(semver.toString(version))
+    return this.updateLink(Branch.Version, result)
   }
 
 }

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -148,9 +148,9 @@ export default class RootTree implements Puttable {
   //
   // {
   //   "currentChunkIndex": 2,
-  //   "0": first_log,
-  //   "1": second_log,
-  //   "2": current_log
+  //   "0": first_chunk,
+  //   "1": second_chunk,
+  //   "2": current_chunk
   // }
   //
   // Chunk size is based on the default IPFS block size,

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -1,0 +1,140 @@
+import { Branch, Links, Puttable } from '../types'
+import { AddResult, CID } from '../../ipfs'
+import { SemVer } from '../semver'
+import * as link from '../link'
+import * as protocol from '../protocol'
+import * as semver from '../semver'
+import BareTree from '../bare/tree'
+import MMPT from '../protocol/private/mmpt'
+import PublicTree from '../v1/PublicTree'
+import PrivateTree from '../v1/PrivateTree'
+
+
+export default class RootTree implements Puttable {
+
+  links: Links
+  mmpt: MMPT
+
+  publicTree: PublicTree
+  prettyTree: BareTree
+  privateTree: PrivateTree
+
+  constructor({ links, mmpt, publicTree, prettyTree, privateTree }: {
+    links: Links,
+    mmpt: MMPT,
+
+    publicTree: PublicTree,
+    prettyTree: BareTree,
+    privateTree: PrivateTree,
+  }) {
+    this.links = links
+    this.mmpt = mmpt
+
+    this.publicTree = publicTree
+    this.prettyTree = prettyTree
+    this.privateTree = privateTree
+  }
+
+
+  // INITIALISATION
+  // --------------
+
+  static async empty({ key }: { key: string }): Promise<RootTree> {
+    const publicTree = await PublicTree.empty()
+    const prettyTree = await BareTree.empty()
+
+    const mmpt = MMPT.create()
+    const privateTree = await PrivateTree.create(mmpt, key, null)
+    await privateTree.put()
+
+    // Construct tree
+    const tree = new RootTree({
+      links: {},
+      mmpt,
+
+      publicTree,
+      prettyTree,
+      privateTree
+    })
+
+    // Set version and store new sub trees
+    tree.setVersion(semver.v1)
+
+    await Promise.all([
+      tree.updatePuttable(Branch.Public, publicTree),
+      tree.updatePuttable(Branch.Pretty, prettyTree),
+      tree.updatePuttable(Branch.Private, mmpt)
+    ])
+
+    // Fin
+    return tree
+  }
+
+  static async fromCID({ cid, key }: { cid: CID, key: string }): Promise<RootTree> {
+    const links = await protocol.basic.getLinks(cid)
+
+    // Load public parts
+    const publicCID = links[Branch.Public]?.cid || null
+    const publicTree = publicCID === null
+      ? await PublicTree.empty()
+      : await PublicTree.fromCID(publicCID)
+
+    const prettyTree = links[Branch.Pretty]
+                         ? await BareTree.fromCID(links[Branch.Pretty].cid)
+                         : await BareTree.empty()
+
+    // Load private bits
+    const privateCID = links[Branch.Private]?.cid || null
+
+    let mmpt, privateTree
+    if (privateCID === null) {
+      mmpt = await MMPT.create()
+      privateTree = await PrivateTree.create(mmpt, key, null)
+    } else {
+      mmpt = await MMPT.fromCID(privateCID)
+      privateTree = await PrivateTree.fromBaseKey(mmpt, key)
+    }
+
+    // Construct tree
+    const tree = new RootTree({
+      links,
+      mmpt,
+
+      publicTree,
+      prettyTree,
+      privateTree
+    })
+
+    // Fin
+    return tree
+  }
+
+
+  // MUTATIONS
+  // ---------
+
+  async put(): Promise<CID> {
+    const { cid } = await this.putDetailed()
+    return cid
+  }
+
+  async putDetailed(): Promise<AddResult> {
+    return protocol.basic.putLinks(this.links)
+  }
+
+  async setVersion(version: SemVer): Promise<this> {
+    const result = await protocol.basic.putFile(semver.toString(version))
+    return this.updateLink("version", result)
+  }
+
+  updateLink(name: string, result: AddResult): this {
+    const { cid, size, isFile } = result
+    this.links[name] = link.make(name, cid, isFile, size)
+    return this
+  }
+
+  async updatePuttable(name: string, puttable: Puttable): Promise<this> {
+    return this.updateLink(name, await puttable.putDetailed())
+  }
+
+}

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -40,6 +40,12 @@ export interface Links { [name: string]: Link }
 // MISC
 // ----
 
+export enum Branch {
+  Public = 'public',
+  Pretty = 'p',
+  Private = 'private'
+}
+
 export type NonEmptyPath = [string, ...string[]]
 
 export interface Puttable {

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -30,11 +30,6 @@ export interface Links { [name: string]: Link }
 // MISC
 // ----
 
-export type UpdateProof = {
-  cid: CID
-  proof?: string
-}
-
 export type NonEmptyPath = [string, ...string[]]
 
 export interface Puttable {

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -1,3 +1,4 @@
+import { Maybe } from '../common'
 import { FileContent, CID, AddResult } from '../ipfs'
 import { SemVer } from './semver'
 
@@ -5,44 +6,53 @@ import { SemVer } from './semver'
 // LINKS
 // -----
 
-export type BaseLink = {
+export interface SimpleLink {
+  name: string
+  size: number
+  cid: CID
+}
+
+export interface BaseLink {
   name: string
   size: number
   mtime?: number
   isFile: boolean
 }
 
-export type Link = BaseLink & {
-  cid: CID
-}
+export interface Link extends SimpleLink, BaseLink {}
 
-export type BaseLinks = { [name: string]: BaseLink }
-export type Links = { [name: string]: Link }
+export interface SimpleLinks { [name: string]: SimpleLink }
+export interface BaseLinks { [name: string]: BaseLink }
+export interface Links { [name: string]: Link }
 
 
 
 // MISC
 // ----
 
-export type PutDetails = {
+export type UpdateProof = {
   cid: CID
-  userland: CID
-  metadata: CID
-  size: number
+  proof?: string
 }
 
 export type NonEmptyPath = [string, ...string[]]
-export type SyncHook = (result: CID, proof: string) => unknown
-export type SyncHookDetailed = (result: AddResult) => unknown
+
+export interface Puttable {
+  put(): Promise<CID>
+  putDetailed(): Promise<AddResult>
+}
+
+export type UpdateCallback = () => Promise<unknown>
+
+export type PublishHook = (result: CID, proof: string) => unknown
 
 
 // FILE
 // -----
 
-export interface File {
+export interface File extends Puttable {
   content: FileContent
-  put(): Promise<CID>
-  putDetailed(): Promise<AddResult>
+  updateContent(content: FileContent): Promise<this>
 }
 
 
@@ -51,7 +61,7 @@ export interface File {
 
 export interface UnixTree {
   ls(path: string): Promise<BaseLinks>
-  mkdir(path: string): Promise<this>
+  mkdir(path: string, onUpdate?: UpdateCallback): Promise<this>
   cat(path: string): Promise<FileContent>
   add(path: string, content: FileContent): Promise<this>
   rm(path: string): Promise<this>
@@ -60,21 +70,22 @@ export interface UnixTree {
   exists(path: string): Promise<boolean>
 }
 
-export interface Tree extends UnixTree {
+export interface Tree extends UnixTree, Puttable {
   version: SemVer
 
-  addChild(path: string, toAdd: Tree | FileContent): Promise<this>
-  addRecurse (path: NonEmptyPath, child: Tree | FileContent): Promise<this>
 
-  put(): Promise<CID>
-  putDetailed(): Promise<AddResult>
-  updateDirectChild (child: Tree | File, name: string): Promise<this>
+  createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree>
+  createOrUpdateChildFile(content: FileContent, name: string, onUpdate: Maybe<UpdateCallback>): Promise<File>
+
+  mkdirRecurse(path: string, onUpdate: Maybe<UpdateCallback>): Promise<this>
+  addRecurse(path: string, content: FileContent, onUpdate: Maybe<UpdateCallback>): Promise<this>
+  rmRecurse(path: string, onUpdate: Maybe<UpdateCallback>): Promise<this>
+
+  updateDirectChild(child: Tree | File, name: string, onUpdate: Maybe<UpdateCallback>): Promise<this>
   removeDirectChild(name: string): this
   getDirectChild(name: string): Promise<Tree | File | null>
-  getOrCreateDirectChild(name: string): Promise<Tree | File>
+  getOrCreateDirectChild(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree | File>
 
-  emptyChildTree(): Promise<Tree>
-  createChildFile(content: FileContent, name: string): Promise<File>
-
+  updateLink(name: string, result: AddResult): this
   getLinks(): BaseLinks
 }

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -43,7 +43,9 @@ export interface Links { [name: string]: Link }
 export enum Branch {
   Public = 'public',
   Pretty = 'p',
-  Private = 'private'
+  Private = 'private',
+  PrivateLog = 'privateLog',
+  Version = 'version'
 }
 
 export type NonEmptyPath = [string, ...string[]]

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -3,6 +3,16 @@ import { FileContent, CID, AddResult } from '../ipfs'
 import { SemVer } from './semver'
 
 
+// FILE
+// -----
+
+export interface File extends Puttable {
+  content: FileContent
+  updateContent(content: FileContent): Promise<this>
+}
+
+
+
 // LINKS
 // -----
 
@@ -42,14 +52,6 @@ export type UpdateCallback = () => Promise<unknown>
 export type PublishHook = (result: CID, proof: string) => unknown
 
 
-// FILE
-// -----
-
-export interface File extends Puttable {
-  content: FileContent
-  updateContent(content: FileContent): Promise<this>
-}
-
 
 // TREE
 // ----
@@ -67,7 +69,6 @@ export interface UnixTree {
 
 export interface Tree extends UnixTree, Puttable {
   version: SemVer
-
 
   createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<Tree>
   createOrUpdateChildFile(content: FileContent, name: string, onUpdate: Maybe<UpdateCallback>): Promise<File>

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -4,7 +4,7 @@
 import { isString, isObject, isNum, isBool } from '../../common'
 import { CID } from '../../ipfs'
 import { Tree, File, Link, Links, BaseLink } from '../types'
-import { Skeleton, TreeInfo, FileInfo, TreeHeader } from '../protocol/public/types'
+import { Skeleton, TreeInfo, FileInfo, TreeHeader, FileHeader } from '../protocol/public/types'
 import { SemVer } from '../semver'
 import { Metadata, UnixMeta } from '../metadata'
 
@@ -72,11 +72,15 @@ export const isTreeInfo = (obj: any): obj is TreeInfo => {
     && isCID((obj as any).userland)
 }
 
-export const isFileInfo = (obj: any): obj is FileInfo => {
+export const isFileHeader = (obj: any): obj is FileHeader => {
   return isObject(obj)
-    && isCID(obj.userland)
     && isMetadata(obj.metadata)
     && obj.metadata.isFile === true
+}
+
+export const isFileInfo = (obj: any): obj is FileInfo => {
+  return isFileHeader(obj)
+    && isCID((obj as any).userland)
 }
 
 export const isCID = (obj: any): obj is CID => {

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -5,7 +5,8 @@ import * as protocol from '../protocol'
 import * as namefilter from '../protocol/private/namefilter'
 import { PrivateName, BareNameFilter } from '../protocol/private/namefilter'
 import MMPT from '../protocol/private/mmpt'
-import { PrivateAddResult, PrivateFileInfo } from '../protocol/private/types'
+import { PrivateAddResult, PrivateFileInfo, Revision } from '../protocol/private/types'
+import { Maybe } from '../../common'
 import { isObject } from '../../common/type-checks'
 import BaseFile from '../base/file'
 import { genKeyStr } from '../../keystore'
@@ -100,6 +101,93 @@ export class PrivateFile extends BaseFile {
       ...this.header,
       metadata: metadata.updateMtime(this.header.metadata)
     }, this.key)
+  }
+
+
+  // REVISIONS
+  // =========
+
+  /**
+   * Get a specific revision of this tree.
+   */
+  async getRevision(revision: number): Promise<PrivateFile | null> {
+    const info = await this._getRevisionInfoFromNumber(revision)
+
+    return info && await PrivateFile.fromInfo(
+      this.mmpt,
+      this.key,
+      info
+    )
+  }
+
+  /**
+   * Get the latest revision of this tree.
+   * That might be this exact one.
+   */
+  async getLatestRevision(): Promise<PrivateFile> {
+    const revision = await this._getLatestRevision()
+    return revision
+      ? await PrivateFile.fromInfo(
+          this.mmpt,
+          this.key,
+          await this._getRevisionInfo(revision)
+        )
+      : this
+  }
+
+  /**
+   * Check if this revision is the latest one.
+   */
+  async isLatestRevision(): Promise<boolean> {
+    const revision = await this._getLatestRevision()
+    return revision?.number === this.header.revision
+  }
+
+  /**
+   * List all previous revisions, this includes
+   * the content CID, the metadata, revision number, etc.
+   */
+  async listRevisions(): Promise<Array<PrivateFileInfo>> {
+    return Promise.all(
+      Array.from({ length: this.header.revision }, (_, i) =>
+        this._getRevisionInfoFromNumber(i + 1)
+      )
+    ).then(
+      list => list.filter(a => !!a) as Array<PrivateFileInfo>
+    )
+  }
+
+  /**
+   * @internal
+   */
+  _getLatestRevision(): Promise<Maybe<Revision>> {
+    return protocol.priv.findLatestRevision(
+      this.mmpt,
+      this.header.bareNameFilter,
+      this.key,
+      this.header.revision || 1
+    )
+  }
+
+  /**
+   * @internal
+   */
+  async _getRevisionInfo(revision: Revision): Promise<PrivateFileInfo> {
+    const info = await protocol.priv.readNode(revision.cid, this.key)
+
+    if (!check.isPrivateFileInfo(info)) {
+      throw new Error(`Could not parse a valid private tree using the given key`)
+    }
+
+    return info
+  }
+
+  async _getRevisionInfoFromNumber(revision: number): Promise<Maybe<PrivateFileInfo>> {
+    const { key, mmpt } = this
+    const { bareNameFilter } = this.header
+
+    const r = await protocol.priv.getRevision(mmpt, bareNameFilter, key, revision)
+    return r && this._getRevisionInfo(r)
   }
 
 }

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -1,4 +1,3 @@
-import { File } from '../types'
 import { FileContent } from '../../ipfs'
 import * as check from '../protocol/private/types/check'
 import * as metadata from '../metadata'
@@ -18,7 +17,7 @@ type ConstructorParams = {
   info: PrivateFileInfo
 }
 
-export class PrivateFile extends BaseFile implements File {
+export class PrivateFile extends BaseFile {
 
   mmpt: MMPT
   key: string
@@ -87,6 +86,7 @@ export class PrivateFile extends BaseFile implements File {
 
   async updateContent(content: FileContent): Promise<this> {
     const contentInfo = await protocol.basic.putEncryptedFile(content, this.info.key)
+    this.content = content
     this.info = {
       ...this.info,
       revision: this.info.revision + 1,

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -110,6 +110,13 @@ export class PrivateFile extends BaseFile {
   // =========
 
   /**
+   * Revision of this instance of the file.
+   */
+  currentRevision(): number {
+    return this.header.revision
+  }
+
+  /**
    * Get a specific revision of this tree.
    */
   async getRevision(revision: number): Promise<PrivateFile | null> {
@@ -146,16 +153,20 @@ export class PrivateFile extends BaseFile {
   }
 
   /**
-   * List all previous revisions, this includes
-   * the content CID, the metadata, revision number, etc.
+   * List all previous revisions along with the timestamp they were created.
    */
-  async listRevisions(): Promise<Array<PrivateFileInfo>> {
+  async listRevisions(): Promise<Array<{ revision: number, timestamp: number }>> {
     return Promise.all(
       Array.from({ length: this.header.revision }, (_, i) =>
         this._getRevisionInfoFromNumber(i + 1)
       )
     ).then(
       list => list.filter(a => !!a) as Array<PrivateFileInfo>
+    ).then(
+      list => list.map(a => ({
+        revision: a.revision,
+        timestamp: a.metadata.unixMeta.mtime
+      }))
     )
   }
 

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -57,7 +57,7 @@ export class PrivateFile extends BaseFile {
   }
 
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateFile> {
-    const info = await protocol.priv.getByName(mmpt, name, key)
+    const info = await protocol.priv.getLatestByName(mmpt, name, key)
     if(!check.isPrivateFileInfo(info)) {
       throw new Error(`Could not parse a valid private file using the given key`)
     }

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -57,10 +57,12 @@ export class PrivateFile extends BaseFile {
   }
 
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateFile> {
-    const info = await protocol.priv.getLatestByName(mmpt, name, key)
-    if(!check.isPrivateFileInfo(info)) {
+    const info = await protocol.priv.getByName(mmpt, name, key)
+
+    if (!check.isPrivateFileInfo(info)) {
       throw new Error(`Could not parse a valid private file using the given key`)
     }
+
     return PrivateFile.fromInfo(mmpt, key, info)
   }
 

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -112,8 +112,11 @@ export class PrivateFile extends BaseFile {
   /**
    * Revision of this instance of the file.
    */
-  currentRevision(): number {
-    return this.header.revision
+  currentRevision(): { revision: number, timestamp: number } {
+    return {
+      revision: this.header.revision,
+      timestamp: this.header.metadata.unixMeta.mtime
+    }
   }
 
   /**

--- a/src/fs/v1/PrivateHistory.ts
+++ b/src/fs/v1/PrivateHistory.ts
@@ -1,0 +1,116 @@
+import MMPT from "../protocol/private/mmpt"
+import { BareNameFilter } from '../protocol/private/namefilter'
+import { DecryptedNode, Revision } from "../protocol/private/types"
+import { Maybe } from '../../common'
+import { Metadata } from '../metadata'
+import * as check from '../protocol/private/types/check'
+import * as protocol from '../protocol'
+
+
+export type Node = {
+  constructor: {
+    fromInfo: (mmpt: MMPT, key: string, info: DecryptedNode) => Node
+  },
+  header: {
+    bareNameFilter: BareNameFilter,
+    metadata: Metadata,
+    revision: number
+  },
+  key: string,
+  mmpt: MMPT
+}
+
+
+export default class PrivateHistory {
+
+  constructor(readonly node: Node) {}
+
+  async back(delta: number = -1): Promise<Maybe<Node>> {
+    const n = Math.min(delta, -1)
+    const revision = this.node.header?.revision
+    return (revision && await this._getRevision(revision + n)) || null
+  }
+
+  async forward(delta: number = 1): Promise<Maybe<Node>> {
+    const n = Math.max(delta, 1)
+    const revision = this.node.header?.revision
+    return (revision && await this._getRevision(revision + n)) || null
+  }
+
+  async prior(timestamp: number): Promise<Maybe<Node>> {
+    if (this.node.header.metadata.unixMeta.mtime < timestamp) {
+      return this.node
+    } else {
+      return this._prior(this.node.header.revision - 1, timestamp)
+    }
+  }
+
+  /**
+   * List earlier versions along with the timestamp they were created.
+   */
+  async list(amount: number): Promise<Array<{ delta: number, timestamp: number }>> {
+    const max = this.node.header.revision
+
+    return Promise.all(
+      Array.from({ length: amount }, (_, i) => {
+        const n = i + 1
+        return this._getRevisionInfoFromNumber(max - n).then(info => ({
+          revisionInfo: info,
+          delta: -n
+        }))
+      })
+    ).then(
+      list => list.filter(a => !!a.revisionInfo) as Array<{ revisionInfo: DecryptedNode, delta: number }>
+    ).then(
+      list => list.map(a => {
+        const mtime = a.revisionInfo.metadata.unixMeta.mtime
+        return { delta: a.delta, timestamp: mtime }
+      })
+    )
+  }
+
+  /**
+   * @internal
+   */
+  async _getRevision(revision: number): Promise<Maybe<Node>> {
+    const info = await this._getRevisionInfoFromNumber(revision)
+    return info && await this.node.constructor.fromInfo(
+      this.node.mmpt,
+      this.node.key,
+      info
+    )
+  }
+
+  /**
+   * @internal
+   */
+  _getRevisionInfo(revision: Revision): Promise<DecryptedNode> {
+    return protocol.priv.readNode(revision.cid, this.node.key)
+  }
+
+  /**
+   * @internal
+   */
+  async _getRevisionInfoFromNumber(revision: number): Promise<Maybe<DecryptedNode>> {
+    const { key, mmpt } = this.node
+    const { bareNameFilter } = this.node.header
+
+    const r = await protocol.priv.getRevision(mmpt, bareNameFilter, key, revision)
+    return r && this._getRevisionInfo(r)
+  }
+
+  /**
+   * @internal
+   */
+  async _prior(revision: number, timestamp: number): Promise<Node | null> {
+    const info = await this._getRevisionInfoFromNumber(revision)
+    if (!info?.revision) return null
+
+    if (info.metadata.unixMeta.mtime < timestamp) {
+      return this._getRevision(info.revision)
+    } else {
+      return this._prior(info.revision - 1, timestamp)
+    }
+  }
+
+}

--- a/src/fs/v1/PrivateHistory.ts
+++ b/src/fs/v1/PrivateHistory.ts
@@ -57,7 +57,7 @@ export default class PrivateHistory {
   /**
    * List earlier versions along with the timestamp they were created.
    */
-  async list(amount: number): Promise<Array<{ delta: number, timestamp: number }>> {
+  async list(amount: number = 5): Promise<Array<{ delta: number, timestamp: number }>> {
     const max = this.node.header.revision
 
     return Promise.all(

--- a/src/fs/v1/PrivateHistory.ts
+++ b/src/fs/v1/PrivateHistory.ts
@@ -3,7 +3,6 @@ import { BareNameFilter } from '../protocol/private/namefilter'
 import { DecryptedNode, Revision } from "../protocol/private/types"
 import { Maybe } from '../../common'
 import { Metadata } from '../metadata'
-import * as check from '../protocol/private/types/check'
 import * as protocol from '../protocol'
 
 
@@ -25,18 +24,28 @@ export default class PrivateHistory {
 
   constructor(readonly node: Node) {}
 
+  /**
+   * Go back one or more versions.
+   *
+   * @param delta Optional negative number to specify how far to go back
+   */
   async back(delta: number = -1): Promise<Maybe<Node>> {
     const n = Math.min(delta, -1)
     const revision = this.node.header?.revision
     return (revision && await this._getRevision(revision + n)) || null
   }
 
-  async forward(delta: number = 1): Promise<Maybe<Node>> {
-    const n = Math.max(delta, 1)
-    const revision = this.node.header?.revision
-    return (revision && await this._getRevision(revision + n)) || null
-  }
+  // async forward(delta: number = 1): Promise<Maybe<Node>> {
+  //   const n = Math.max(delta, 1)
+  //   const revision = this.node.header?.revision
+  //   return (revision && await this._getRevision(revision + n)) || null
+  // }
 
+  /**
+   * Get a version before a given timestamp.
+   *
+   * @param timestamp Unix timestamp in seconds
+   */
   async prior(timestamp: number): Promise<Maybe<Node>> {
     if (this.node.header.metadata.unixMeta.mtime < timestamp) {
       return this.node
@@ -102,7 +111,7 @@ export default class PrivateHistory {
   /**
    * @internal
    */
-  async _prior(revision: number, timestamp: number): Promise<Node | null> {
+  async _prior(revision: number, timestamp: number): Promise<Maybe<Node>> {
     const info = await this._getRevisionInfoFromNumber(revision)
     if (!info?.revision) return null
 

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -238,8 +238,11 @@ export default class PrivateTree extends BaseTree {
   /**
    * Revision of this instance of the tree.
    */
-  currentRevision(): number {
-    return this.header.revision
+  currentRevision(): { revision: number, timestamp: number } {
+    return {
+      revision: this.header.revision,
+      timestamp: this.header.metadata.unixMeta.mtime
+    }
   }
 
   /**

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -236,6 +236,13 @@ export default class PrivateTree extends BaseTree {
   // =========
 
   /**
+   * Revision of this instance of the tree.
+   */
+  currentRevision(): number {
+    return this.header.revision
+  }
+
+  /**
    * Get a specific revision of this tree.
    */
   async getRevision(revision: number): Promise<PrivateTree | null> {
@@ -272,16 +279,20 @@ export default class PrivateTree extends BaseTree {
   }
 
   /**
-   * List all previous revisions, this includes
-   * the content CID, the metadata, revision number, etc.
+   * List all previous revisions along with the timestamp they were created.
    */
-  async listRevisions(): Promise<Array<PrivateTreeInfo>> {
+  async listRevisions(): Promise<Array<{ revision: number, timestamp: number }>> {
     return Promise.all(
       Array.from({ length: this.header.revision }, (_, i) =>
         this._getRevisionInfoFromNumber(i + 1)
       )
     ).then(
       list => list.filter(a => !!a) as Array<PrivateTreeInfo>
+    ).then(
+      list => list.map(a => ({
+        revision: a.revision,
+        timestamp: a.metadata.unixMeta.mtime
+      }))
     )
   }
 

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -81,6 +81,15 @@ export default class PrivateTree extends BaseTree {
   async createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<PrivateTree> {
     const key = await genKeyStr()
     const child = await PrivateTree.create(this.mmpt, key, this.info.bareNameFilter)
+
+    const existing = this.children[name]
+    if(existing) {
+      if(PrivateFile.instanceOf(existing)) {
+        throw new Error(`There is a file at the given path: ${name}`)
+      }
+      return existing
+    }
+
     await this.updateDirectChild(child, name, onUpdate)
     return child
   }

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -67,7 +67,7 @@ export default class PrivateTree extends BaseTree {
   }
 
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateTree> {
-    const info = await protocol.priv.getByName(mmpt, name, key)
+    const info = await protocol.priv.getLatestByName(mmpt, name, key)
     if(!check.isPrivateTreeInfo(info)) {
       throw new Error(`Could not parse a valid private tree using the given key`)
     }
@@ -187,14 +187,14 @@ export default class PrivateTree extends BaseTree {
   async getRecurse(nodeInfo: PrivateSkeletonInfo, parts: string[]): Promise<Maybe<DecryptedNode>> {
     const [head, ...rest] = parts
     if(head === undefined) {
-      return protocol.priv.getByCID(this.mmpt, nodeInfo.cid, nodeInfo.key)
+      return protocol.priv.getLatestByCID(this.mmpt, nodeInfo.cid, nodeInfo.key)
     }
     const nextChild = nodeInfo.subSkeleton[head]
     if(nextChild !== undefined) {
       return this.getRecurse(nextChild, rest)
     }
 
-    const reloadedNode = await protocol.priv.getByCID(this.mmpt, nodeInfo.cid, nodeInfo.key)
+    const reloadedNode = await protocol.priv.getLatestByCID(this.mmpt, nodeInfo.cid, nodeInfo.key)
     if(!check.isPrivateTreeInfo(reloadedNode)){
       return null
     }

--- a/src/fs/v1/PublicFile.ts
+++ b/src/fs/v1/PublicFile.ts
@@ -1,27 +1,32 @@
 import { FileInfo, FileHeader, PutDetails } from '../protocol/public/types'
 import { CID, FileContent } from '../../ipfs'
 import BaseFile from '../base/file'
+import PublicHistory from './PublicHistory'
+import * as check from '../types/check'
+import * as history from './PublicHistory'
 import * as metadata from '../metadata'
 import * as protocol from '../protocol'
-import * as check from '../types/check'
 import { isObject, Maybe } from '../../common'
 
 
 type ConstructorParams = {
+  cid: Maybe<CID>
   content: FileContent,
   header: FileHeader
-  cid: Maybe<CID>
 }
 
 export class PublicFile extends BaseFile {
 
-  header: FileHeader
   cid: Maybe<CID>
+  header: FileHeader
+  history: PublicHistory
 
   constructor({ content, header, cid }: ConstructorParams) {
     super(content)
-    this.header = header
+
     this.cid = cid
+    this.header = header
+    this.history = new PublicHistory(this as unknown as history.Node)
   }
 
   static instanceOf(obj: any): obj is PublicFile {

--- a/src/fs/v1/PublicFile.ts
+++ b/src/fs/v1/PublicFile.ts
@@ -8,7 +8,7 @@ import { isObject, Maybe } from '../../common'
 
 
 type ConstructorParams = {
-  content: FileContent, 
+  content: FileContent,
   header: FileHeader
   cid: Maybe<CID>
 }
@@ -32,8 +32,8 @@ export class PublicFile extends BaseFile {
 
   static async create(content: FileContent): Promise<PublicFile> {
     return new PublicFile({
-      content, 
-      header: { metadata:  metadata.empty(true) },
+      content,
+      header: { metadata: metadata.empty(true) },
       cid: null
     })
   }
@@ -44,18 +44,18 @@ export class PublicFile extends BaseFile {
   }
 
   static async fromInfo(info: FileInfo, cid: CID): Promise<PublicFile> {
-    const { userland, metadata } = info
+    const { userland, metadata, previous } = info
     const content = await protocol.basic.getFile(userland)
-    return new PublicFile({ 
-      content, 
-      header: { metadata },
+    return new PublicFile({
+      content,
+      header: { metadata, previous },
       cid
     })
   }
 
   async putDetailed(): Promise<PutDetails> {
     const details = await protocol.pub.putFile(
-      this.content, 
+      this.content,
       metadata.updateMtime(this.header.metadata),
       this.cid
     )

--- a/src/fs/v1/PublicHistory.ts
+++ b/src/fs/v1/PublicHistory.ts
@@ -1,0 +1,97 @@
+import { CID } from '../../ipfs'
+import { Maybe } from '../../common'
+import { Metadata } from '../metadata'
+import * as protocol from '../protocol'
+
+
+export type Node = {
+  constructor: {
+    fromCID: (cid: CID) => Node
+  },
+  header: {
+    metadata: Metadata,
+    previous: CID
+  }
+}
+
+
+export default class PublicHistory {
+
+  constructor(readonly node: Node) {}
+
+  /**
+   * Go back one or more versions.
+   *
+   * @param delta Optional negative number to specify how far to go back
+   */
+  back(delta: number = -1): Promise<Maybe<Node>> {
+    const length = Math.abs(Math.min(delta, -1))
+
+    return Array.from({ length }, (_, i) => i).reduce(
+      (promise: Promise<Maybe<Node>>) => promise.then(
+        (n: Maybe<Node>) => n ? PublicHistory._getPreviousVersion(n) : null
+      ),
+      Promise.resolve(this.node)
+    )
+  }
+
+  // async forward(delta: number = 1): Promise<Maybe<Node>> {}
+
+  /**
+   * Get a version before a given timestamp.
+   *
+   * @param timestamp Unix timestamp in seconds
+   */
+  async prior(timestamp: number): Promise<Maybe<Node>> {
+    return PublicHistory._prior(this.node, timestamp)
+  }
+
+  /**
+   * List earlier versions along with the timestamp they were created.
+   */
+  async list(amount: number): Promise<Array<{ delta: number, timestamp: number }>> {
+    const { acc } = await Array.from({ length: amount }, (_, i) => i).reduce(
+      (promise, i) => promise.then(({ node, acc }) => {
+        if (!node) return Promise.resolve({ node: null, acc })
+
+        return PublicHistory
+          ._getPreviousVersion(node)
+          .then(n => ({
+            node: n,
+            acc: [
+              ...acc,
+              { delta: -(i + 1), timestamp: node.header.metadata.unixMeta.mtime }
+            ]
+          }))
+      }),
+      PublicHistory
+        ._getPreviousVersion(this.node)
+        .then(n => (
+          { node: n, acc: [] } as {
+            node: Maybe<Node>,
+            acc: Array<{ delta: number, timestamp: number }>
+          }
+        ))
+    )
+
+    return acc
+  }
+
+  /**
+   * @internal
+   */
+  static async _getPreviousVersion(node: Node): Promise<Maybe<Node>> {
+    if (!node.header.previous) return Promise.resolve(null)
+    return node.constructor.fromCID(node.header.previous)
+  }
+
+  /**
+   * @internal
+   */
+  static async _prior(node: Node, timestamp: number): Promise<Maybe<Node>> {
+    if (node.header.metadata.unixMeta.mtime < timestamp) return node
+    const previous = await PublicHistory._getPreviousVersion(node)
+    return previous ? PublicHistory._prior(previous, timestamp) : null
+  }
+
+}

--- a/src/fs/v1/PublicHistory.ts
+++ b/src/fs/v1/PublicHistory.ts
@@ -49,7 +49,7 @@ export default class PublicHistory {
   /**
    * List earlier versions along with the timestamp they were created.
    */
-  async list(amount: number): Promise<Array<{ delta: number, timestamp: number }>> {
+  async list(amount: number = 5): Promise<Array<{ delta: number, timestamp: number }>> {
     const { acc } = await Array.from({ length: amount }, (_, i) => i).reduce(
       (promise, i) => promise.then(({ node, acc }) => {
         if (!node) return Promise.resolve({ node: null, acc })

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -68,6 +68,15 @@ export class PublicTree extends BaseTree {
 
   async createChildTree(name: string, onUpdate: Maybe<UpdateCallback>): Promise<PublicTree> {
     const child = await PublicTree.empty()
+
+    const existing = this.children[name]
+    if(existing) {
+      if(PublicFile.instanceOf(existing)) {
+        throw new Error(`There is a file at the given path: ${name}`)
+      }
+      return existing
+    }
+
     await this.updateDirectChild(child, name, onUpdate)
     return child
   }

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -1,40 +1,46 @@
-import { Links, UpdateCallback } from '../types'
-import { TreeInfo, TreeHeader, PutDetails } from '../protocol/public/types'
-import * as check from '../types/check'
 import { CID, FileContent } from '../../ipfs'
+import { Links, UpdateCallback } from '../types'
+import { Maybe } from '../../common'
+import { TreeInfo, TreeHeader, PutDetails } from '../protocol/public/types'
 import BaseTree from '../base/tree'
 import BareTree from '../bare/tree'
 import PublicFile from './PublicFile'
+import PublicHistory from './PublicHistory'
+import * as check from '../types/check'
+import * as history from './PublicHistory'
+import * as link from '../link'
+import * as metadata from '../metadata'
+import * as pathUtil from '../path'
 import * as protocol from '../protocol'
 import * as skeleton from '../protocol/public/skeleton'
-import * as metadata from '../metadata'
-import * as link from '../link'
-import * as pathUtil from '../path'
-import { Maybe } from '../../common'
+
 
 type ConstructorParams = {
+  cid: Maybe<CID>
   links: Links
   header: TreeHeader
-  cid: Maybe<CID>
 }
 
 type Child =
   PublicFile | PublicTree | BareTree
 
+
 export class PublicTree extends BaseTree {
 
+  children: { [name: string]: Child }
+  cid: Maybe<CID>
   links: Links
   header: TreeHeader
-  cid: Maybe<CID>
-
-  children: { [name: string]: Child }
+  history: PublicHistory
 
   constructor({ links, header, cid }: ConstructorParams) {
     super(header.metadata.version)
+
+    this.children = {}
+    this.cid = cid
     this.links = links
     this.header = header
-    this.cid = cid
-    this.children = {}
+    this.history = new PublicHistory(this as unknown as history.Node)
   }
 
   static async empty (): Promise<PublicTree> {

--- a/src/fs/v1/PublicTree.ts
+++ b/src/fs/v1/PublicTree.ts
@@ -53,11 +53,11 @@ export class PublicTree extends BaseTree {
   }
 
   static async fromInfo(info: TreeInfo, cid: CID): Promise<PublicTree> {
-    const { userland, metadata, skeleton } = info
+    const { userland, metadata, previous, skeleton } = info
     const links = await protocol.basic.getLinks(userland)
-    return new PublicTree({ 
-      links, 
-      header: { metadata, skeleton },
+    return new PublicTree({
+      links,
+      header: { metadata, previous, skeleton },
       cid
     })
   }
@@ -97,7 +97,7 @@ export class PublicTree extends BaseTree {
 
   async putDetailed(): Promise<PutDetails> {
     const details = await protocol.pub.putTree(
-      this.links, 
+      this.links,
       this.header.skeleton,
       this.header.metadata,
       this.cid
@@ -151,7 +151,7 @@ export class PublicTree extends BaseTree {
     if(skeletonInfo === null) return null
 
     const info = await protocol.pub.get(skeletonInfo.cid)
-    return check.isFileInfo(info) 
+    return check.isFileInfo(info)
       ? PublicFile.fromInfo(info, skeletonInfo.cid)
       : PublicTree.fromInfo(info, skeletonInfo.cid)
   }

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -11,7 +11,8 @@ export const add = async (content: FileContent): Promise<AddResult> => {
 
   return {
     cid: result.cid.toString(),
-    size: result.size
+    size: result.size,
+    isFile: true
   }
 }
 
@@ -58,7 +59,11 @@ export const dagPut = async (node: DAGNode): Promise<AddResult> => {
   const cidObj = await ipfs.dag.put(node, { format: 'dag-pb', hashAlg: 'sha2-256' })
   const cid = cidObj.toV1().toString()
   const nodeSize = await size(cid)
-  return { cid, size: nodeSize }
+  return { 
+    cid, 
+    size: nodeSize,
+    isFile: false
+  }
 }
 
 export const dagPutLinks = async (links: DAGLink[]): Promise<AddResult> => {

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -1,6 +1,6 @@
 import dagPB from 'ipld-dag-pb'
 import { get as getIpfs } from './config'
-import { CID, FileContent, DAGNode, UnixFSFile, DAGLink, AddResult } from './types'
+import { CID, FileContent, DAGNode, UnixFSFile, DAGLink, AddResult, RawDAGNode } from './types'
 import util from './util'
 import { DAG_NODE_DATA } from './constants'
 
@@ -48,7 +48,7 @@ export const ls = async (cid: CID): Promise<UnixFSFile[]> => {
 export const dagGet = async (cid: CID): Promise<DAGNode> => {
   const ipfs = await getIpfs()
   await attemptPin(cid)
-  const raw = await ipfs.dag.get(cid)
+  const raw = await ipfs.dag.get(cid) as RawDAGNode
   return util.rawToDAGNode(raw)
 }
 
@@ -59,8 +59,8 @@ export const dagPut = async (node: DAGNode): Promise<AddResult> => {
   const cidObj = await ipfs.dag.put(node, { format: 'dag-pb', hashAlg: 'sha2-256' })
   const cid = cidObj.toV1().toString()
   const nodeSize = await size(cid)
-  return { 
-    cid, 
+  return {
+    cid,
     size: nodeSize,
     isFile: false
   }

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -43,7 +43,7 @@ export type RawDAGLink = {
 
 export interface DagAPI {
   put(dagNode: unknown, options?: unknown): Promise<CIDObj>
-  get(cid: string | CID, path?: string, options?: unknown): Promise<RawDAGNode>
+  get(cid: string | CID, path?: string, options?: unknown): Promise<{ value: unknown, remainderPath: string }>
   resolve(cid: string | CID | CIDObj): Promise<{ cid: CIDObj }>
   tree(cid: string | CID, path?: string, options?: unknown): Promise<Array<string>>
 }

--- a/src/ipfs/types.ts
+++ b/src/ipfs/types.ts
@@ -103,6 +103,7 @@ export type ObjStat = {
 export type AddResult = {
   cid: CID
   size: number
+  isFile: boolean
 }
 
 export type SwarmAPI = {


### PR DESCRIPTION
## Problem
The Filesystem does not allow concurrent operations. Two write operations at the same time will overwrite one another.

## Solution
- make the MMPT concurrent
- make the filesystem concurrent
- also roll in changes for versioning on the public side (https://github.com/fission-suite/webnative/pull/125) to avoid rebases etc