### PR TITLE
Clear all data when leaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,34 @@
 # Changelog
 
+### v0.19.8
+
+Bugfix: clear all data when using the `leave` function.
+
+
 ### v0.19.7
 
-Bugfix: updates to files on public side were failing
+Bugfix: updates to files on public side were failing.
+
 
 ### v0.19.6
 
-Bugfix: changes to public tree were not being reflected in pretty tree
+Bugfix: changes to public tree were not being reflected in pretty tree.
+
 
 ### v0.19.5
 
-Don't error on failed pins
+Don't error on failed pins.
+
 
 ### v0.19.2
 
-Do not recursively pin content
+Do not recursively pin content.
+
 
 ### v0.19.1
 
 Permissions should be optional for `redirectToLobby` and `loadFileSystem` as well.
+
 
 ### v0.19
 
@@ -30,6 +40,7 @@ Permissions should be optional for `redirectToLobby` and `loadFileSystem` as wel
 ### v0.18.1
 
 Added proofs to JWT for app routes (index, create & delete)
+
 
 ### v0.18.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.7",
+  "version": "0.19.8-alpha-1",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.8-alpha-1",
+  "version": "0.19.8",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,9 @@
 import localforage from 'localforage'
 
+import * as cidLog from './common/cid-log'
 import * as common from './common'
 import * as did from './did'
+import * as keystore from './keystore'
 import * as ucan from './ucan/internal'
 import { UCANS_STORAGE_KEY, USERNAME_STORAGE_KEY, Maybe } from './common'
 import { Permissions } from './ucan/permissions'
@@ -26,6 +28,8 @@ export async function authenticatedUsername(): Promise<string | null> {
 export async function leave(): Promise<void> {
   await localforage.removeItem(USERNAME_STORAGE_KEY)
   await ucan.clearStorage()
+  await cidLog.clear()
+  await keystore.clear()
 
   window.location.href = setup.endpoints.lobby
 }

--- a/src/common/cid-log.ts
+++ b/src/common/cid-log.ts
@@ -36,3 +36,8 @@ export async function add(cid: string): Promise<void> {
   const newLog = [ cid, ...log ].slice(0, 1000)
   await localforage.setItem(key(), newLog)
 }
+
+
+export async function clear(): Promise<void> {
+  await localforage.removeItem(key())
+}


### PR DESCRIPTION
Wasn't clearing all the data before, which was causing some issues when creating a new account. More specifically, the sdk tried to load a different file system because the CID log was still in the indexeddb. Additionally I cleared the keystore as well, so the user starts with fresh keys.