### PR TITLE
Support the decoding of the url-safe base64 encoded read-key from the auth lobby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.19.10
+
+Support the decoding of the url-safe base64 encoded read-key from the auth lobby.
+
+
 ### v0.19.9
 
 The expiration timestamp of a UCAN cannot exceed that of its proof.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "description": "Fission Typescript SDK",
   "keywords": [],
   "main": "index.cjs.js",

--- a/src/common/base64.ts
+++ b/src/common/base64.ts
@@ -9,3 +9,7 @@ export function urlEncode(b: string): string {
 export function makeUrlSafe(a: string): string {
   return a.replace(/\//g, "_").replace(/\+/g, "-").replace(/=+$/, "")
 }
+
+export function makeUrlUnsafe(a: string): string {
+  return a.replace(/_/g, "/").replace(/-/g, "+")
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export async function initialise(
     const username = url.searchParams.get("username") || ""
 
     const ks = await keystore.get()
-    const readKey = await ks.decrypt(encryptedReadKey)
+    const readKey = await ks.decrypt(common.base64.makeUrlUnsafe(encryptedReadKey))
     await ks.importSymmKey(readKey, READ_KEY_FROM_LOBBY_NAME)
     await localforage.setItem(USERNAME_STORAGE_KEY, username)
 


### PR DESCRIPTION
I'm making the base64 of the encoded read-key url-safe on the auth lobby side. Now it supports both url-safe and non url-safe base64.

Context: Fixing this https://github.com/fission-suite/auth-lobby/issues/21