### PR TITLE
Fix regex for usernames & allow underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.21.5
+
+Fix regex of username validation and allow non-prefixed underscores in usernames
+
 ### v0.21.4
 
 Does not cancel data-root updates anymore, slightly increasing the performance of concurrent writes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -1,11 +1,10 @@
-import * as dataRoot from '../data-root'
 import * as did from '../did'
 import * as ucan from '../ucan'
 import * as ucanInternal from '../ucan/internal'
 import { api } from '../common'
 import { setup } from '../setup/internal'
 
-import { USERNAME_BLOCKLIST } from './blocklist'
+export * from './username'
 
 
 /**
@@ -38,25 +37,6 @@ export async function createAccount(
   }
 }
 
-/**
- * Check if a username is available.
- */
-export async function isUsernameAvailable(
-  username: string
-): Promise<boolean> {
-  const resp = await fetch(`${setup.endpoints.api}/user/data/${username}`)
-  return !resp.ok
-}
-
-/**
- * Check if a username is valid.
- */
-export function isUsernameValid(username: string): boolean {
-  return !username.startsWith("-") &&
-         !username.endsWith("-") &&
-         !!username.match(/[a-zA-Z1-9-]+/) &&
-         !USERNAME_BLOCKLIST.includes(username)
-}
 
 /**
  * Ask the fission server to send another verification email to the

--- a/src/lobby/username.test.ts
+++ b/src/lobby/username.test.ts
@@ -22,6 +22,10 @@ describe('isUsernameValid', () => {
     expect(isUsernameValid("reCovErY")).toBe(false)
   })
 
+  it("does not allow empty strings", () => {
+    expect(isUsernameValid("")).toBe(false)
+  })
+
   it("does not allow special characters", () => {
     expect(isUsernameValid("plus+plus")).toBe(false)
   })

--- a/src/lobby/username.test.ts
+++ b/src/lobby/username.test.ts
@@ -1,0 +1,57 @@
+import { isUsernameValid } from "./username"
+
+describe('isUsernameValid', () => {
+
+  it("allows basic usernames", () => {
+    expect(isUsernameValid("simple")).toBe(true)
+  })
+  
+  it("allows internal hyphens", () => {
+    expect(isUsernameValid("happy-name")).toBe(true)
+  })
+  
+  it("allows internal underscores", () => {
+    expect(isUsernameValid("under_score")).toBe(true)
+  })
+
+  it("does not allow blocklisted words", () => {
+    expect(isUsernameValid("recovery")).toBe(false)
+  })
+
+  it("is not case sensitive", () => {
+    expect(isUsernameValid("reCovErY")).toBe(false)
+  })
+
+  it("does not allow special characters", () => {
+    expect(isUsernameValid("plus+plus")).toBe(false)
+  })
+  
+  it("does not allow prefixed hyphens", () => {
+    expect(isUsernameValid("-startswith")).toBe(false)
+  })
+  
+  it("does not allow suffixed hyphens", () => {
+    expect(isUsernameValid("endswith-")).toBe(false)
+  })
+  
+  it("does not allow prefixed underscores", () => {
+    expect(isUsernameValid("_startswith")).toBe(false)
+  })
+  
+  it("does not allow spaces", () => {
+    expect(isUsernameValid("with space")).toBe(false)
+  })
+  
+  it("does not allow dots", () => {
+    expect(isUsernameValid("with.dot")).toBe(false)
+  })
+  
+  it("does not allow two dots", () => {
+    expect(isUsernameValid("has.two.dots")).toBe(false)
+  })
+  
+  it("does not allow special characters", () => {
+    expect(isUsernameValid("name&with#chars")).toBe(false)
+  })
+ 
+})

--- a/src/lobby/username.ts
+++ b/src/lobby/username.ts
@@ -19,6 +19,6 @@ export function isUsernameValid(username: string): boolean {
   return !username.startsWith("-") &&
          !username.endsWith("-") &&
          !username.startsWith("_") &&
-         /^[a-zA-Z1-9_-]*$/.test(username) &&
+         /^[a-zA-Z1-9_-]+$/.test(username) &&
          !USERNAME_BLOCKLIST.includes(username.toLowerCase())
 }

--- a/src/lobby/username.ts
+++ b/src/lobby/username.ts
@@ -1,0 +1,24 @@
+import { setup } from '../setup/internal'
+
+import { USERNAME_BLOCKLIST } from './blocklist'
+
+/**
+ * Check if a username is available.
+ */
+export async function isUsernameAvailable(
+  username: string
+): Promise<boolean> {
+  const resp = await fetch(`${setup.endpoints.api}/user/data/${username}`)
+  return !resp.ok
+}
+
+/**
+ * Check if a username is valid.
+ */
+export function isUsernameValid(username: string): boolean {
+  return !username.startsWith("-") &&
+         !username.endsWith("-") &&
+         !username.startsWith("_") &&
+         /^[a-zA-Z1-9_-]*$/.test(username) &&
+         !USERNAME_BLOCKLIST.includes(username.toLowerCase())
+}


### PR DESCRIPTION
## Problem
Today, users are restricted to non-underscored usernames and app names (subdomains).

also our regex check isn't properly disallowing bad usernames (worst case our server rejects but would still be nice to give a user a heads up)

## Solution
- Allow underscores in the validator
- disallow usernames that start with underscores so that we don't have conflicts with _did, _dataroot, _dnslink, etc
- fix regex so it doesn't allow special characters (someone plz double check my regex! it appears to work well, but regex has always been a weak spot for me)
- lowercase usernames before checking against block list
- still allow uppercase because that all gets normalized on the server
