### PR TITLE
Add common unit tests and prop checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:prod": "yarn run build && yarn run lint && yarn run test -- --no-cache",
+    "test:unit": "jest --watch --testPathPattern=src/",
     "precommit": "lint-staged",
     "prepublishOnly": "yarn build && yarn docs",
     "publish-dry": "npm publish --dry-run",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-jest": "^26.6.3",
     "braces": "^3.0.2",
     "eslint": "^7.18.0",
+    "fast-check": "^2.14.0",
     "jest": "^26.6.3",
     "jest-config": "^26.6.3",
     "jest-puppeteer": "^4.4.0",

--- a/src/common/arrbufs.test.ts
+++ b/src/common/arrbufs.test.ts
@@ -8,8 +8,14 @@ describe('arrbufs equal', () => {
   })
 
   it('returns false on different buffers', () => {
-    const buffA = new Uint8Array([ 0xed, 0x01 ])
-    const buffB = new Uint8Array([ 0xed, 0x02 ])
+    const buffA = new Uint8Array([0xed, 0x01])
+    const buffB = new Uint8Array([0xed, 0x02])
+    expect(equal(buffA, buffB)).toBe(false)
+  })
+
+  it('returns false on buffers with different lengths', () => {
+    const buffA = new Uint8Array([0x01, 0x02])
+    const buffB = new Uint8Array([0x01, 0x02, 0x03])
     expect(equal(buffA, buffB)).toBe(false)
   })
 })

--- a/src/common/arrbufs.test.ts
+++ b/src/common/arrbufs.test.ts
@@ -1,21 +1,22 @@
+import * as fc from 'fast-check';
 import { equal } from './arrbufs'
 
-describe('arrbufs equal', () => {
-  it('returns true on identical buffers', () => {
-    const buffA = new ArrayBuffer(8)
-    const buffB = new ArrayBuffer(8)
-    expect(equal(buffA, buffB)).toBe(true)
-  })
+test('arrbufs equal', () => {
+  fc.assert(
+    fc.property(fc.uint8Array(), data => {
+      expect(equal(data.buffer, data.buffer)).toBe(true);
+    })
+  )
+})
 
-  it('returns false on different buffers', () => {
-    const buffA = new Uint8Array([0xed, 0x01])
-    const buffB = new Uint8Array([0xed, 0x02])
-    expect(equal(buffA, buffB)).toBe(false)
-  })
-
-  it('returns false on buffers with different lengths', () => {
-    const buffA = new Uint8Array([0x01, 0x02])
-    const buffB = new Uint8Array([0x01, 0x02, 0x03])
-    expect(equal(buffA, buffB)).toBe(false)
-  })
+test('arrbufs not equal', () => {
+  fc.assert(
+    fc.property(
+      fc.tuple(
+        fc.uint8Array({ minLength: 3 }),
+        fc.uint8Array({ minLength: 3 })
+      ), data => {
+        expect(equal(data[0].buffer, data[1].buffer)).toBe(false);
+      })
+  )
 })

--- a/src/common/base64.test.ts
+++ b/src/common/base64.test.ts
@@ -1,10 +1,15 @@
 /**
  * @jest-environment jsdom
  */
+import * as fc from 'fast-check';
 import * as base64 from './base64'
 
-test('can decode an encoded string', () => {
-  const testString = 'ab/c-d=='
-  const encoded = base64.urlEncode(testString)
-  expect(base64.urlDecode(encoded)).toEqual(testString)
+test('round trip encode and decode a string', () => {
+  fc.assert(
+    fc.property(fc.string({ maxLength: 2000 }), data => {
+      const encodedData = base64.urlEncode(data)
+      const decodedData = base64.urlDecode(encodedData)
+      expect(data).toEqual(decodedData)
+    })
+  );
 })

--- a/src/common/base64.test.ts
+++ b/src/common/base64.test.ts
@@ -4,9 +4,9 @@
 import * as fc from 'fast-check';
 import * as base64 from './base64'
 
-test('round trip encode and decode a string', () => {
+test('round trip encode and decode a url', () => {
   fc.assert(
-    fc.property(fc.string({ maxLength: 2000 }), data => {
+    fc.property(fc.string({ maxLength: 4000 }), data => {
       const encodedData = base64.urlEncode(data)
       const decodedData = base64.urlDecode(encodedData)
       expect(data).toEqual(decodedData)

--- a/src/common/hex.test.ts
+++ b/src/common/hex.test.ts
@@ -1,0 +1,26 @@
+import * as fc from 'fast-check';
+import { fromBuffer, toBuffer } from './hex'
+
+test('round trip to buffer and back out', () => {
+  fc.assert(
+    fc.property(fc.array(fc.integer(16, 255)), data => {
+      const hexData = []
+      const buffers = []
+      const returnData = []
+
+      for (const num of data) {
+        hexData.push(num.toString(16))
+      }
+
+      for (const hex of hexData) {
+        buffers.push(toBuffer(hex))
+      }
+
+      for (const buffer of buffers) {
+        returnData.push(fromBuffer(buffer))
+      }
+
+      expect(returnData).toEqual(hexData)
+    })
+  );
+});

--- a/src/common/type-check.test.ts
+++ b/src/common/type-check.test.ts
@@ -1,8 +1,25 @@
+import * as fc from 'fast-check';
 import * as check from './type-checks'
 
+
 describe('is defined', () => {
-  it('returns true when passed a value', () => {
-    expect(check.isDefined(1)).toBe(true)
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isDefined(data)).toEqual(true)
+    })
+  )
+
+  it('returns true when passed true', () => {
+    expect(check.isDefined(true)).toBe(true)
+  })
+
+  it('returns true when passed false', () => {
+    expect(check.isDefined(false)).toBe(true)
   })
 
   it('returns true when passed a null', () => {
@@ -16,8 +33,23 @@ describe('is defined', () => {
 
 
 describe('not null', () => {
-  it('returns true when passed a value', () => {
-    expect(check.notNull(1)).toBe(true)
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.notNull(data)).toEqual(true)
+    })
+  )
+
+  it('returns true when passed true', () => {
+    expect(check.notNull(true)).toBe(true)
+  })
+
+  it('returns true when passed false', () => {
+    expect(check.notNull(false)).toBe(true)
   })
 
   it('returns true when passed undefined', () => {
@@ -30,8 +62,23 @@ describe('not null', () => {
 })
 
 describe('is just', () => {
-  it('returns true when passed a value', () => {
-    expect(check.isJust(1)).toBe(true)
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isJust(data)).toEqual(true)
+    })
+  )
+
+  it('returns true when passed true', () => {
+    expect(check.isJust(true)).toBe(true)
+  })
+
+  it('returns true when passed false', () => {
+    expect(check.isJust(false)).toBe(true)
   })
 
   it('returns true when passed undefined', () => {
@@ -44,8 +91,23 @@ describe('is just', () => {
 })
 
 describe('is value', () => {
-  it('returns true when passed a value', () => {
-    expect(check.isValue(1)).toBe(true)
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isValue(data)).toEqual(true)
+    })
+  )
+
+  it('returns true when passed true', () => {
+    expect(check.isValue(true)).toBe(true)
+  })
+
+  it('returns true when passed false', () => {
+    expect(check.isValue(false)).toBe(true)
   })
 
   it('returns false when passed undefined', () => {
@@ -66,9 +128,16 @@ describe('is boolean', () => {
     expect(check.isBool(false)).toBe(true)
   })
 
-  it('returns false when passed a non-boolean value', () => {
-    expect(check.isBool(1)).toBe(false)
-  })
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isBool(data)).toEqual(false)
+    })
+  )
 
   it('returns false when passed a null', () => {
     expect(check.isBool(null)).toBe(false)
@@ -80,21 +149,15 @@ describe('is boolean', () => {
 })
 
 describe('is num', () => {
-  it('returns true when passed a number', () => {
-    expect(check.isNum(1)).toBe(true)
-  })
-
-  it('returns true when passed a hex number', () => {
-    expect(check.isNum(0x1)).toBe(true)
-  })
-
-  it('returns true when passed a binary number', () => {
-    expect(check.isNum(0b1)).toBe(true)
-  })
-
-  it('returns true when passed a octal number', () => {
-    expect(check.isNum(0o1)).toBe(true)
-  })
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.float(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isNum(data)).toEqual(true)
+    })
+  )
 
   it('returns true when passed infinity', () => {
     expect(check.isNum(Infinity)).toBe(true)
@@ -104,8 +167,25 @@ describe('is num', () => {
     expect(check.isNum(-Infinity)).toBe(true)
   })
 
-  it('returns false when passed a non-numeric value', () => {
-    expect(check.isNum('1')).toBe(false)
+  it('returns true when passed a NaN', () => {
+    expect(check.isNum(NaN)).toBe(true)
+  })
+
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.string(), weight: 5 },
+    ), data => {
+      expect(check.isNum(data)).toEqual(false)
+    })
+  )
+
+  it('returns false when passed true', () => {
+    expect(check.isNum(true)).toBe(false)
+  })
+
+  it('returns false when passed false', () => {
+    expect(check.isNum(false)).toBe(false)
   })
 
   it('returns false when passed undefined', () => {
@@ -117,17 +197,30 @@ describe('is num', () => {
   })
 })
 
+
 describe('is string', () => {
-  it('returns true when passed a string', () => {
-    expect(check.isString('a')).toBe(true)
+  fc.assert(
+    fc.property(fc.string(), data => {
+      expect(check.isString(data)).toEqual(true)
+    })
+  )
+
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.object(), weight: 10 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isString(data)).toEqual(false)
+    })
+  )
+
+  it('returns false when passed true', () => {
+    expect(check.isString(true)).toBe(false)
   })
 
-  it('returns true when passed an empty string', () => {
-    expect(check.isString('')).toBe(true)
-  })
-
-  it('returns false when passed an non-string value', () => {
-    expect(check.isString(1)).toBe(false)
+  it('returns false when passed false', () => {
+    expect(check.isString(false)).toBe(false)
   })
 
   it('returns false when passed undefined ', () => {
@@ -140,16 +233,28 @@ describe('is string', () => {
 })
 
 describe('is object', () => {
-  it('returns true when passed a object', () => {
-    expect(check.isObject({ a: 1 })).toBe(true)
+  fc.assert(
+    fc.property(fc.object(), data => {
+      expect(check.isObject(data)).toEqual(true)
+    })
+  )
+
+  fc.assert(
+    fc.property(fc.frequency(
+      { arbitrary: fc.string(), weight: 5 },
+      { arbitrary: fc.integer(), weight: 1 },
+      { arbitrary: fc.double(), weight: 1 }
+    ), data => {
+      expect(check.isObject(data)).toEqual(false)
+    })
+  )
+
+  it('returns false when passed true', () => {
+    expect(check.isObject(true)).toBe(false)
   })
 
-  it('returns true when passed an empty object', () => {
-    expect(check.isObject({})).toBe(true)
-  })
-
-  it('returns false when passed an non-object value', () => {
-    expect(check.isObject(1)).toBe(false)
+  it('returns false when passed false', () => {
+    expect(check.isObject(false)).toBe(false)
   })
 
   it('returns false when passed undefined ', () => {

--- a/src/common/type-check.test.ts
+++ b/src/common/type-check.test.ts
@@ -1,0 +1,162 @@
+import * as check from './type-checks'
+
+describe('is defined', () => {
+  it('returns true when passed a value', () => {
+    expect(check.isDefined(1)).toBe(true)
+  })
+
+  it('returns true when passed a null', () => {
+    expect(check.isDefined(null)).toBe(true)
+  })
+
+  it('returns false when passed undefined', () => {
+    expect(check.isDefined(undefined)).toBe(false)
+  })
+})
+
+
+describe('not null', () => {
+  it('returns true when passed a value', () => {
+    expect(check.notNull(1)).toBe(true)
+  })
+
+  it('returns true when passed undefined', () => {
+    expect(check.notNull(undefined)).toBe(true)
+  })
+
+  it('returns false when passed a null', () => {
+    expect(check.notNull(null)).toBe(false)
+  })
+})
+
+describe('is just', () => {
+  it('returns true when passed a value', () => {
+    expect(check.isJust(1)).toBe(true)
+  })
+
+  it('returns true when passed undefined', () => {
+    expect(check.isJust(undefined)).toBe(true)
+  })
+
+  it('returns false when passed a null', () => {
+    expect(check.isJust(null)).toBe(false)
+  })
+})
+
+describe('is value', () => {
+  it('returns true when passed a value', () => {
+    expect(check.isValue(1)).toBe(true)
+  })
+
+  it('returns false when passed undefined', () => {
+    expect(check.isValue(undefined)).toBe(false)
+  })
+
+  it('returns false when passed a null', () => {
+    expect(check.isValue(null)).toBe(false)
+  })
+})
+
+describe('is boolean', () => {
+  it('returns true when passed true', () => {
+    expect(check.isBool(true)).toBe(true)
+  })
+
+  it('returns true when passed false', () => {
+    expect(check.isBool(false)).toBe(true)
+  })
+
+  it('returns false when passed a non-boolean value', () => {
+    expect(check.isBool(1)).toBe(false)
+  })
+
+  it('returns false when passed a null', () => {
+    expect(check.isBool(null)).toBe(false)
+  })
+
+  it('returns false when passed a undefined', () => {
+    expect(check.isBool(undefined)).toBe(false)
+  })
+})
+
+describe('is num', () => {
+  it('returns true when passed a number', () => {
+    expect(check.isNum(1)).toBe(true)
+  })
+
+  it('returns true when passed a hex number', () => {
+    expect(check.isNum(0x1)).toBe(true)
+  })
+
+  it('returns true when passed a binary number', () => {
+    expect(check.isNum(0b1)).toBe(true)
+  })
+
+  it('returns true when passed a octal number', () => {
+    expect(check.isNum(0o1)).toBe(true)
+  })
+
+  it('returns true when passed infinity', () => {
+    expect(check.isNum(Infinity)).toBe(true)
+  })
+
+  it('returns true when passed negative infinity', () => {
+    expect(check.isNum(-Infinity)).toBe(true)
+  })
+
+  it('returns false when passed a non-numeric value', () => {
+    expect(check.isNum('1')).toBe(false)
+  })
+
+  it('returns false when passed undefined', () => {
+    expect(check.isNum(undefined)).toBe(false)
+  })
+
+  it('returns false when passed null', () => {
+    expect(check.isNum(null)).toBe(false)
+  })
+})
+
+describe('is string', () => {
+  it('returns true when passed a string', () => {
+    expect(check.isString('a')).toBe(true)
+  })
+
+  it('returns true when passed an empty string', () => {
+    expect(check.isString('')).toBe(true)
+  })
+
+  it('returns false when passed an non-string value', () => {
+    expect(check.isString(1)).toBe(false)
+  })
+
+  it('returns false when passed undefined ', () => {
+    expect(check.isString(undefined)).toBe(false)
+  })
+
+  it('returns false when passed null', () => {
+    expect(check.isString(null)).toBe(false)
+  })
+})
+
+describe('is object', () => {
+  it('returns true when passed a object', () => {
+    expect(check.isObject({ a: 1 })).toBe(true)
+  })
+
+  it('returns true when passed an empty object', () => {
+    expect(check.isObject({})).toBe(true)
+  })
+
+  it('returns false when passed an non-object value', () => {
+    expect(check.isObject(1)).toBe(false)
+  })
+
+  it('returns false when passed undefined ', () => {
+    expect(check.isObject(undefined)).toBe(false)
+  })
+
+  it('returns false when passed null', () => {
+    expect(check.isObject(null)).toBe(false)
+  })
+})

--- a/src/common/util.test.ts
+++ b/src/common/util.test.ts
@@ -1,0 +1,125 @@
+import * as util from './util'
+
+describe('removes a key from an object', () => {
+  it('removes a key from an object', () => {
+    const obj = { a: 1, b: 2 }
+    expect(util.removeKeyFromObj(obj, 'b')).toEqual({ a: 1 })
+  })
+
+  it('removes the last key and returns an empty object', () => {
+    const obj = { a: 1 }
+    expect(util.removeKeyFromObj(obj, 'a')).toEqual({})
+  })
+
+  it('returns the same object when the key is missing', () => {
+    const obj = { a: 1 }
+    expect(util.removeKeyFromObj(obj, 'b')).toEqual({ a: 1 })
+  })
+})
+
+describe('updates a value or removes a key from an object', () => {
+  it('updates an object', () => {
+    const obj = { a: 1 }
+    expect(util.updateOrRemoveKeyFromObj(obj, 'a', 2)).toEqual({ a: 2 })
+  })
+
+  it('removes a key from an object', () => {
+    const obj = { a: 1, b: 2 }
+    expect(util.updateOrRemoveKeyFromObj(obj, 'b', null)).toEqual({ a: 1 })
+  })
+
+  it('adds a key when missing on an object', () => {
+    const obj = { a: 1 }
+    expect(util.updateOrRemoveKeyFromObj(obj, 'b', 2)).toEqual({ a: 1, b: 2 })
+  })
+
+  it('does not add a key when the update value is null', () => {
+    const obj = { a: 1 }
+    expect(util.updateOrRemoveKeyFromObj(obj, 'b', null)).toEqual({ a: 1 })
+  })
+})
+
+describe('maps over an object', () => {
+  it('adds one to each entry in an object', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    expect(util.mapObj(obj, ((val, key) => val + 1))).toEqual({ a: 2, b: 3, c: 4 })
+  })
+
+  it('nullifies each entry in an object', () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    expect(util.mapObj(obj, ((val, key) => null))).toEqual({ a: null, b: null, c: null })
+  })
+
+  it('has no effect on an empty object', () => {
+    const obj = {}
+    expect(util.mapObj(obj, ((val, key) => null))).toEqual({})
+  })
+
+  it('sets each entries value to its key', () => {
+    const obj = { a: 1, b: 2 }
+    expect(util.mapObj(obj, ((val, key) => key))).toEqual({ a: 'a', b: 'b' })
+  })
+})
+
+describe('async maps over an object', () => {
+  it('adds one to each entry in an object', async () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    async function addOne(val, key) { return val + 1 }
+    expect(util.mapObjAsync(obj, addOne)).resolves.toEqual({ a: 2, b: 3, c: 4 })
+  })
+
+  it('nullifies each entry in an object', async () => {
+    const obj = { a: 1, b: 2, c: 3 }
+    async function nullify(val, key) { return null }
+    expect(util.mapObjAsync(obj, nullify)).resolves.toEqual({ a: null, b: null, c: null })
+  })
+
+  it('has no effect on an empty object', async () => {
+    const obj = {}
+    async function nullify(val, key) { return null }
+    expect(util.mapObjAsync(obj, nullify)).resolves.toEqual({})
+  })
+
+  it('sets each entries value to its key', async () => {
+    const obj = { a: 1, b: 2 }
+    async function setToKey(val, key) { return key }
+    expect(util.mapObjAsync(obj, setToKey)).resolves.toEqual({ a: 'a', b: 'b' })
+  })
+})
+
+describe('array contains', () => {
+  it('returns true when an array contains an entry', () => {
+    const arr = [1, 2, 3]
+    expect(util.arrContains(arr, 2)).toBe(true);
+  })
+
+  it('returns false when an array does not contain an entry', () => {
+    const arr = [1, 2, 3]
+    expect(util.arrContains(arr, 0)).toBe(false);
+  })
+
+  it('returns false when an array is empty', () => {
+    const arr = []
+    expect(util.arrContains(arr, 1)).toBe(false);
+  })
+})
+
+describe('async waterfall', () => {
+  it('accumulates values returned from async calls', async () => {
+    async function addOne(val) { return val + 1 }
+    async function addTwo(val) { return val + 2 }
+    async function addThree(val) { return val + 3 }
+    expect(util.asyncWaterfall(0, [addOne, addTwo, addThree])).resolves.toEqual(6)
+  })
+
+  it('concatenates characters returned from async calls', async () => {
+    async function concatB(val) { return val + 'b' }
+    async function concatC(val) { return val + 'c' }
+    async function concatD(val) { return val + 'd' }
+    expect(util.asyncWaterfall('a', [concatB, concatC, concatD])).resolves.toEqual('abcd')
+  })
+
+  it('returns the initial value when no waterfall', async () => {
+    expect(util.asyncWaterfall(0, [])).resolves.toEqual(0)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,13 @@ eyes@0.1.x:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
+fast-check@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-2.14.0.tgz#13e891977a7cc1ba87aa3883c75053990c02fb21"
+  integrity sha512-4hm0ioyEVCwgjBLBqriwAFYu3/yc7pNH9fBfvzi6JRWRs4R3mwZwrr/d4MHbY0fTBJ0Uakg4TaMAAQ8Cnt2+KQ==
+  dependencies:
+    pure-rand "^4.1.1"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5073,6 +5080,11 @@ puppeteer@^5.5.0:
     tar-fs "^2.0.0"
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
+
+pure-rand@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-4.1.2.tgz#cbad2a3e3ea6df0a8d80d8ba204779b5679a5205"
+  integrity sha512-uLzZpQWfroIqyFWmX/pl0OL2JHJdoU3dbh0dvZ25fChHFJJi56J5oQZhW6QgbT2Llwh1upki84LnTwlZvsungA==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Add unit tests and prop checks
* [x] Add npm script to run unit tests and prop checks only

This PR brings in a unit tests and property checks for modules in `src/common/`. 

## Test plan (required)

A run of the tests with `npm run test:unit` should result in:

![common-tests](https://user-images.githubusercontent.com/7957636/113036134-c264f080-9148-11eb-8ebd-2b2dfd42cc54.png)

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

