### PR TITLE
Notify the lobby we're using a shared worker

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -59,6 +59,7 @@ export async function redirectToLobby(
 
   const exchangeDid = await did.exchange()
   const writeDid = await did.write()
+  const sharedRepo = !!document.body.querySelector("iframe[src$=\"/ipfs.html\"]") && typeof SharedWorker === "function"
 
   redirectTo = redirectTo || window.location.href
 
@@ -67,7 +68,8 @@ export async function redirectToLobby(
     [ "didExchange", exchangeDid ],
     [ "didWrite", writeDid ],
     [ "redirectTo", redirectTo ],
-    [ "sdk", VERSION.toString() ]
+    [ "sdk", VERSION.toString() ],
+    [ "sharedRepo", sharedRepo ? "t" : "f" ]
 
   ].concat(
     app                     ? [[ "appFolder", `${app.creator}/${app.name}` ]] : [],

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -59,7 +59,7 @@ export async function redirectToLobby(
 
   const exchangeDid = await did.exchange()
   const writeDid = await did.write()
-  const sharedRepo = !!document.body.querySelector("iframe[src$=\"/ipfs.html\"]") && typeof SharedWorker === "function"
+  const sharedRepo = !!document.body.querySelector("iframe#webnative-ipfs") && typeof SharedWorker === "function"
 
   redirectTo = redirectTo || window.location.href
 

--- a/src/ipfs/config.ts
+++ b/src/ipfs/config.ts
@@ -21,6 +21,7 @@ export const get = async (): Promise<IPFS> => {
 export function iframe(): Promise<MessagePort> {
   return new Promise((resolve, reject) => {
     const iframe = document.createElement("iframe")
+    iframe.id = "webnative-ipfs"
     iframe.style.width = "0"
     iframe.style.height = "0"
     iframe.style.border = "none"


### PR DESCRIPTION
Lets us optimise for the fast path.
Adds the temporary auth data to the shared worker via ipfs, instead of to the user's filesystem.