### PR TITLE
Keep existing UCANs in their original state

### DIFF
--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -70,7 +70,7 @@ export async function lookupOnFisson(
  */
 export async function update(
   cid: CID | string,
-  proof: Ucan
+  proof: string
 ): Promise<{ success: boolean }> {
   const apiEndpoint = setup.endpoints.api
 
@@ -88,7 +88,7 @@ export async function update(
 
         // TODO: Waiting on API change.
         //       Should be `username.fission.name/*`
-        resource: proof.payload.rsc
+        resource: ucan.decode(proof).payload.rsc
       }))
 
       return { 'authorization': `Bearer ${jwt}` }

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -1,7 +1,6 @@
 import { Maybe } from '../common'
 import { FileContent, CID, AddResult } from '../ipfs'
 import { SemVer } from './semver'
-import { Ucan } from '../ucan'
 
 
 // FILE
@@ -58,7 +57,7 @@ export interface Puttable {
 
 export type UpdateCallback = () => Promise<unknown>
 
-export type PublishHook = (result: CID, proof: Ucan) => unknown
+export type PublishHook = (result: CID, proof: string) => unknown
 
 
 

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -145,7 +145,7 @@ export function compileDictionary(ucans: Array<string>): Record<string, string> 
     if (isExpired(ucan)) return acc
 
     if (typeof rsc !== "object") {
-      return { ...acc, [rsc]: ucan }
+      return { ...acc, [rsc]: ucanString }
     }
 
     const resource = Array.from(Object.entries(rsc))[0]

--- a/src/ucan.ts
+++ b/src/ucan.ts
@@ -184,7 +184,7 @@ export function encode(ucan: Ucan): string {
 
   return encodedHeader + '.' +
          encodedPayload + '.' +
-         (ucan.signature || sign(ucan.header, ucan.payload))
+         ucan.signature
 }
 
 /**


### PR DESCRIPTION
The idea here is to follow the convention of the fission server, and that's to never re-encode a UCAN. For example, we ran into issues because of a `prf: null` and `prf: undefined` inconsistency. The reason this was happening is because we decoded UCANs from other sources and then re-encoded them. This PR changes that.

Also fixes a issue with `ucan.encode`, namely that it could return an unexpected Promise.