### PR TITLE
Load private files in root tree

### DIFF
--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -345,7 +345,7 @@ export class FileSystem {
       : "query"
 
     if (!this.localOnly) {
-      const proof = await ucanInternal.lookupFilesystemUcan({ directory: parts })
+      const proof = await ucanInternal.lookupFilesystemUcan(path)
       const decodedProof = proof && ucan.decode(proof)
 
       if (!proof || !decodedProof || ucan.isExpired(decodedProof) || !decodedProof.signature) {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -335,7 +335,6 @@ export class FileSystem {
     isMutation: boolean,
     fn: (node: UnixTree | File, relPath: Path) => Promise<a>
   ): Promise<a> {
-    console.log('path: ', path)
     const parts = pathing.unwrap(path)
     const head = parts[0]
     const relPath = parts.slice(1)

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -361,7 +361,7 @@ export class FileSystem {
       )
 
       if (isMutation && PrivateTree.instanceOf(result)) {
-        this.root.privateTrees[pathing.toPosix(treePath)] = result
+        this.root.privateNodes[pathing.toPosix(treePath)] = result
         await result.put()
         await this.root.updatePuttable(Branch.Private, this.root.mmpt)
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -309,6 +309,7 @@ export class FileSystem {
     isMutation: boolean,
     fn: (tree: UnixTree, relPath: Path) => Promise<a>
   ): Promise<a> {
+    console.log('path: ', path)
     const parts = pathing.unwrap(path)
     const head = parts[0]
     const relPath = parts.slice(1)

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -59,6 +59,12 @@ export const getLatestByCID = async (mmpt: MMPT, cid: CID, key: string): Promise
     : node
 }
 
+export const getLatestByBareNameFilter = async(mmpt: MMPT, bareName: BareNameFilter, key:string): Promise<Maybe<DecryptedNode>> => {
+  const revisionFilter = await namefilter.addRevision(bareName, key, 1)
+  const name = await namefilter.toPrivateName(revisionFilter)
+  return getByLatestName(mmpt, name, key)
+}
+
 export const findLatestRevision = async (mmpt: MMPT, bareName: BareNameFilter, key: string, lastKnownRevision: number): Promise<Maybe<Revision>> => {
   // Exponential search forward
   let lowerBound = lastKnownRevision, upperBound = null

--- a/src/fs/protocol/private/types/check.ts
+++ b/src/fs/protocol/private/types/check.ts
@@ -23,6 +23,17 @@ export const isPrivateTreeInfo = (obj: any): obj is PrivateTreeInfo => {
     && isPrivateSkeleton(obj.skeleton)
 }
 
+export const isPrivateTreeInfoLog = (obj: any): void => {
+  console.log(isObject(obj))
+  console.log(check.isMetadata(obj.metadata))
+  console.log(obj.metadata.isFile === false)
+  console.log(isNum(obj.revision))
+  console.log(isPrivateLinks(obj.links))
+  console.log(isPrivateSkeleton(obj.skeleton))
+}
+
+
+
 export const isPrivateLink = (obj: any): obj is PrivateLink => {
   return check.isBaseLink(obj)
     && isString((obj as any).key)

--- a/src/fs/protocol/private/types/check.ts
+++ b/src/fs/protocol/private/types/check.ts
@@ -23,17 +23,6 @@ export const isPrivateTreeInfo = (obj: any): obj is PrivateTreeInfo => {
     && isPrivateSkeleton(obj.skeleton)
 }
 
-export const isPrivateTreeInfoLog = (obj: any): void => {
-  console.log(isObject(obj))
-  console.log(check.isMetadata(obj.metadata))
-  console.log(obj.metadata.isFile === false)
-  console.log(isNum(obj.revision))
-  console.log(isPrivateLinks(obj.links))
-  console.log(isPrivateSkeleton(obj.skeleton))
-}
-
-
-
 export const isPrivateLink = (obj: any): obj is PrivateLink => {
   return check.isBaseLink(obj)
     && isString((obj as any).key)

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -317,15 +317,10 @@ function loadPrivateNodes(
       } else {
         const bareNameFilter = await findBareNameFilter(map, path)
         if (!bareNameFilter) throw new Error(`Was trying to load the PrivateTree for the path \`${path}\`, but couldn't find the bare name filter for it.`)
-
-        const maybeInfo = await protocol.priv.getLatestByBareNameFilter(mmpt, bareNameFilter, key)
-        if (maybeInfo === null) throw new Error(`Could not find content in filesystem for path ${path}`)
-        if(check.isPrivateTreeInfo(maybeInfo)) {
-          privateNode = await PrivateTree.fromInfo(mmpt, key, maybeInfo)
-        } else if(check.isPrivateFileInfo(maybeInfo)) {
-          privateNode = await PrivateFile.fromInfo(mmpt, key, maybeInfo)
+        if (pathing.isDirectory(path)) {
+          privateNode = await PrivateTree.fromBareNameFilter(mmpt, bareNameFilter, key)
         } else {
-          throw new Error(`Could not decipher a valid filesystem object at path ${path}`)
+          privateNode = await PrivateFile.fromBareNameFilter(mmpt, bareNameFilter, key)
         }
       }
 

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -183,7 +183,7 @@ export default class RootTree implements Puttable {
     await crypto.keystore.importSymmKey(rootKey, rootKeyId)
   }
 
-  findPrivateTree(path: DistinctivePath): [DistinctivePath, PrivateNode | null] {
+  findPrivateNode(path: DistinctivePath): [DistinctivePath, PrivateNode | null] {
     return findPrivateNode(this.privateNodes, path)
   }
 
@@ -273,9 +273,11 @@ async function findBareNameFilter(
 
   const unwrappedPath = pathing.unwrap(path)
   const relativePath = unwrappedPath.slice(pathing.unwrap(nodePath).length)
-  if(PrivateFile.instanceOf(node)) {
+
+  if (PrivateFile.instanceOf(node)) {
     return relativePath.length === 0 ? node.header.bareNameFilter : null
   }
+
   if (!node.exists(relativePath)) {
     if (pathing.isDirectory(path)) await node.mkdir(relativePath)
     else await node.add(relativePath, "")

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -68,7 +68,6 @@ export default class PrivateTree extends BaseTree {
 
   static async fromBaseKey(mmpt: MMPT, key: string): Promise<PrivateTree> {
     const bareNameFilter = await namefilter.createBare(key)
-    console.log('fromBaseKey')
     return this.fromBareNameFilter(mmpt, bareNameFilter, key)
   }
 
@@ -79,20 +78,16 @@ export default class PrivateTree extends BaseTree {
 
   static async fromLatestName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateTree> {
     const info = await protocol.priv.getByLatestName(mmpt, name, key)
-    console.log('fromLatestName')
     return this.fromInfo(mmpt, key, info)
   }
 
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateTree> {
     const info = await protocol.priv.getByName(mmpt, name, key)
-    console.log('fromName')
     return this.fromInfo(mmpt, key, info)
   }
 
   static async fromInfo(mmpt: MMPT, key: string, info: Maybe<DecryptedNode>): Promise<PrivateTree> {
     if (!check.isPrivateTreeInfo(info)) {
-      console.log("HERE: ", info)
-      check.isPrivateTreeInfoLog(info)
       throw new Error(`Could not parse a valid private tree using the given key`)
     }
 

--- a/src/fs/v1/PrivateTree.ts
+++ b/src/fs/v1/PrivateTree.ts
@@ -68,29 +68,31 @@ export default class PrivateTree extends BaseTree {
 
   static async fromBaseKey(mmpt: MMPT, key: string): Promise<PrivateTree> {
     const bareNameFilter = await namefilter.createBare(key)
+    console.log('fromBaseKey')
     return this.fromBareNameFilter(mmpt, bareNameFilter, key)
   }
 
   static async fromBareNameFilter(mmpt: MMPT, bareNameFilter: BareNameFilter, key: string): Promise<PrivateTree> {
-    const revisionFilter = await namefilter.addRevision(bareNameFilter, key, 1)
-    const name = await namefilter.toPrivateName(revisionFilter)
-    const info = await protocol.priv.getByLatestName(mmpt, name, key)
-
+    const info = await protocol.priv.getLatestByBareNameFilter(mmpt, bareNameFilter, key)
     return this.fromInfo(mmpt, key, info)
   }
 
   static async fromLatestName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateTree> {
     const info = await protocol.priv.getByLatestName(mmpt, name, key)
+    console.log('fromLatestName')
     return this.fromInfo(mmpt, key, info)
   }
 
   static async fromName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateTree> {
     const info = await protocol.priv.getByName(mmpt, name, key)
+    console.log('fromName')
     return this.fromInfo(mmpt, key, info)
   }
 
   static async fromInfo(mmpt: MMPT, key: string, info: Maybe<DecryptedNode>): Promise<PrivateTree> {
     if (!check.isPrivateTreeInfo(info)) {
+      console.log("HERE: ", info)
+      check.isPrivateTreeInfoLog(info)
       throw new Error(`Could not parse a valid private tree using the given key`)
     }
 

--- a/src/ucan/internal.ts
+++ b/src/ucan/internal.ts
@@ -60,7 +60,7 @@ export async function lookupFilesystemUcan(path: DistinctivePath | "*"): Promise
     (acc: string | null, part: string, idx: number) => {
       if (acc) return acc
 
-      const isLastPart = (idx + 1 === pathParts.length)
+      const isLastPart = idx === 0
       const partsSlice = pathParts.slice(0, pathParts.length - idx)
 
       const partialPath = pathing.toPosix(


### PR DESCRIPTION
## Problem
The private side of the sdk expects all entry points to be directories. But we can now permission files as entry points

## Solution
Allow both files & directories as entry points on the private side