### PR TITLE
Implement new flow for exchanging secrets with the auth lobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.24.0",
+  "version": "0.24.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.24.2",
+  "version": "0.24.0",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION: string = "0.24.2"
+export const VERSION = "0.24.0"

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.24.1-alpha"
+export const VERSION: string = "0.24.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,6 +370,7 @@ async function importClassifiedInfo(
 async function getClassifiedViaPostMessage(): Promise<string> {
   const iframe: HTMLIFrameElement = await new Promise((resolve, reject) => {
     const iframe = document.createElement("iframe")
+    iframe.id = "webnative-secret-exchange"
     iframe.style.width = "0"
     iframe.style.height = "0"
     iframe.style.border = "none"


### PR DESCRIPTION
Depends on https://github.com/fission-suite/auth-lobby/pull/72

Creates a small iframe to exchange the linking secrets with the auth lobby.
The auth lobby can signal that it supports this flow by providing the query parameter `authoised=via-postmessage` after redirecting back from `redirectToLobby`.

