### PR TITLE
Reduce number of entries tested

### DIFF
--- a/src/fs/protocol/private/mmpt.test.ts
+++ b/src/fs/protocol/private/mmpt.test.ts
@@ -55,7 +55,7 @@ describe("the mmpt", () => {
     const mmpt = MMPT.create()
 
     // Generate lots of entries
-    const amount = 2000
+    const amount = 500
     const entries = await generateExampleEntries(amount)
 
     // Concurrently add all those entries to the MMPT
@@ -74,7 +74,7 @@ describe("the mmpt", () => {
     const mmpt = MMPT.create()
 
     // Generate lots of entries
-    const amount = 1000
+    const amount = 500
     const entries = await generateExampleEntries(amount)
 
     const slice_size = 5


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Reduce the number of entries to 500 in "can handle concurrent adds" test
* [x] Reduce the number of entries to 500 in "can handle concurrent adds in batches" test

We are reducing the number of tests so that this test is less time-consuming. See #221.

## Test plan (required)

Run `npm run test` to run the test suite. `mmpt.test.ts` should take around 40 seconds.

## Closing issues

Closes #221 

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release

