### PR TITLE
Browser detection should include workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+### v0.24.2
+
+Fixed issue with browser detection, didn't work in web/service workers.
+
+
 ### v0.24.1
 
 Fix a couple of bugs in dependency injection
+
+
 ### v0.24.0
 
 - Dependency injection for crypto and storage functions to allow for use in Node.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/browser.ts
+++ b/src/common/browser.ts
@@ -1,8 +1,7 @@
-// Took this one-liner from: https://www.npmjs.com/package/browser-or-node
-export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'
+export const isBrowser = typeof self !== "undefined" && typeof self.location === "object"
 
 export const assertBrowser = (method: string): void => {
-  if(!isBrowser) {
+  if (!isBrowser) {
     throw new Error(`Must be in browser to use method. Provide a node-compatible implementation for ${method}`)
   }
 }

--- a/src/crypto/browser.ts
+++ b/src/crypto/browser.ts
@@ -31,7 +31,7 @@ export const genKeyStr = async (): Promise<string> => {
 export const decryptGCM = async (encrypted: string, keyStr: string, ivStr: string): Promise<string> => {
   assertBrowser('aes.decryptGCM')
   const iv = utils.base64ToArrBuf(ivStr)
-  const sessionKey = await window.crypto.subtle.importKey(
+  const sessionKey = await crypto.subtle.importKey(
     "raw",
     utils.base64ToArrBuf(keyStr),
     "AES-GCM",
@@ -40,7 +40,7 @@ export const decryptGCM = async (encrypted: string, keyStr: string, ivStr: strin
   )
 
   // Decrypt secrets
-  const decrypted = await window.crypto.subtle.decrypt(
+  const decrypted = await crypto.subtle.decrypt(
     {
       name: "AES-GCM",
       iv: iv


### PR DESCRIPTION
The browser detection was assuming the `window` object which is not available in web/service workers. This PR replaces that with a check for the `location` object, which is both available on main ui thread (window object) and [worker contexts](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope).

Published this as `0.24.1-alpha-2` if you want to test it.