### PR TITLE
Improve the secret exchange flow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import * as storage from './storage'
 import * as ucan from './ucan/internal'
 import * as ucanPermissions from './ucan/permissions'
 import { setup } from './setup/internal'
+import * as did from './did'
 
 import { USERNAME_STORAGE_KEY, Maybe } from './common'
 import { Permissions } from './ucan/permissions'
@@ -400,8 +401,10 @@ async function getClassifiedViaPostMessage(): Promise<string> {
     })
 
     if (iframe.contentWindow == null) throw new Error("Can't import UCANs & readKey(s): No access to its contentWindow")
-    // Technically, the message doesn't matter
-    const message = { webnative: "exchange-secrets" }
+    const message = {
+      webnative: "exchange-secrets",
+      didExchange: await did.exchange()
+    }
     iframe.contentWindow.postMessage(message, iframe.src)
 
     return await answer


### PR DESCRIPTION
Related to https://github.com/fission-suite/auth-lobby/pull/76

## Summary

> This PR fixes/implements the following **bugs/features**

* On secret retrieval during first authentication, webnative will send the app's exchange DID

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

This will fix bugs when multiple apps try to authenticate with the auth lobby at the same time

## Test plan (required)

> Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

I've tested this against a newer auth-lobby at https://philipps-auth-test.fission.app and with https://dashboard-altlobby.fission.app/ built with this branch.

I've also tested https://dashboard-develop.fission.app with the lobby endpoint modified to philipps-auth-test (backwards compatibility one way) and https://dashboard-altlobby.fission.app/ with the lobby endpoint modified to auth.fission.codes (backwards compatibility the other way).

## Details

If the auth lobby doesn't support this new flow, yet, it doesn't matter:
Older versions of the auth lobby will just ignore the message sent and retrieve the secrets for you anyway (except that this process is then prone to concurrency bugs).