### PR TITLE
Fix tsc output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.25.1
+### v0.25.2
 
 Typescript output to `dist/` instead of `dist/src/`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### v0.25.1
 
+Typescript output to `dist/` instead of `dist/src/`
+
+
+### v0.25.1
+
 Fix naming for minified UMD build
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.25.1"
+export const VERSION = "0.25.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,11 @@
     ]
   },
   "include": [
-    "src"
+    "src/**/*"
   ],
   "exclude": [
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "tests/**/*",
+    "src/setup/jest.ts"
   ]
 }


### PR DESCRIPTION
## Problem
tsc is outputting built files to `dist/src/` instead of `dist`. This breaks type references such as `types` in `package.json`

## Solution
This is because some code in `src` (specifically `setup/jest.ts`) references some code in `tests/`

So we exclude `src/setup/jest.ts` in `tsconfig.ts`