### PR TITLE
Also clear the keystore when it wasn't loaded before

### DIFF
--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -9,10 +9,9 @@ let ks: RSAKeyStore | null = null
 
 
 export const clear = async (): Promise<void> => {
-  if (ks) {
-    await ks.destroy()
-    ks = null
-  }
+  ks = await get()
+  await ks.destroy()
+  ks = null
 }
 
 export const create = async (): Promise<RSAKeyStore> => {


### PR DESCRIPTION
Fixes a bug where calling `webnative.crypto.keystore.clear()` wouldn't actually clear the keystore unless you ran some other keystore operation before which would've internally loaded it.