### PR TITLE
Bring back the umd build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Next
+
+- Bring back the [UMD](https://github.com/umdjs/umd) build (#261)
+
+
 ### v0.26.0
 
 - Export maps, you can now import `webnative/path` instead of `webnative/dist/path`

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "yarn eslint src/**/*.ts",
     "prebuild": "rimraf lib dist && node scripts/gen-version.js",
     "build": "ttsc && yarn run build:minified && cp src/package.json lib/package.json",
-    "build:minified": "esbuild src/index.ts --outfile=dist/index.min.js --bundle --minify --sourcemap --platform=browser --format=iife --global-name=globalThis.webnative --target=es2020 && gzip -k9 dist/index.min.js",
+    "build:minified": "node scripts/build-minified.js",
     "start": "ttsc -w",
     "test": "jest --forceExit",
     "test:watch": "jest --watch",

--- a/scripts/build-minified.js
+++ b/scripts/build-minified.js
@@ -1,0 +1,62 @@
+const esbuild = require('esbuild')
+const fs = require('fs')
+const zlib = require('zlib')
+
+
+const globalName = "webnative"
+const outfile = "dist/index.umd.min.js"
+const outfileGz = `${outfile}.gz`
+
+// From https://github.com/umdjs/umd/blob/36fd1135ba44e758c7371e7af72295acdebce010/templates/returnExports.js
+const umd = {
+    banner:
+`(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.${globalName} = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {  `,
+    footer:
+`return ${globalName};
+}));`
+}
+
+console.log("📦 bundling & minifying...")
+
+esbuild.buildSync({
+    entryPoints: ["src/index.ts"],
+    outfile,
+    bundle: true,
+    minify: true,
+    sourcemap: true,
+    platform: "browser",
+    format: "iife",
+    target: "es2020",
+    globalName,
+    banner: {
+        js: umd.banner,
+    },
+    footer: {
+        js: umd.footer,
+    },
+})
+
+console.log(`📝 Wrote ${outfile} and ${outfile}.map`)
+
+console.log("💎 compressing into .gz")
+
+const fileContents = fs.createReadStream(outfile)
+const writeStream = fs.createWriteStream(outfileGz)
+const gzip = zlib.createGzip()
+
+fileContents.pipe(gzip).pipe(writeStream)
+
+console.log(`📝 Wrote ${outfileGz}`)

--- a/tests/fixtures/index.html
+++ b/tests/fixtures/index.html
@@ -24,7 +24,7 @@
     }
 
   </script>
-  <script src="../../dist/index.min.js"></script>
+  <script src="../../dist/index.umd.min.js"></script>
   <script>
     webnative.setup.endpoints({
       api: "https://runfission.net",

--- a/tests/helpers/page.ts
+++ b/tests/helpers/page.ts
@@ -26,9 +26,9 @@ export async function loadWebnativePage(): Promise<void> {
   })
   if (!isWebnativeLoaded) {
     try {
-      await fs.readFile(path.join(__dirname, "../../dist/index.min.js"))
+      await fs.readFile(path.join(__dirname, "../../dist/index.umd.min.js"))
     } catch {
-      throw new Error("Can't load webpage without a built browser bundle (dist/index.min.js). Please yarn build first.")
+      throw new Error("Can't load webpage without a built browser bundle (dist/index.umd.min.js). Please yarn build first.")
     }
     throw new Error("Couldn't load webnative in the browser for unknown reasons.")
   }


### PR DESCRIPTION
## Summary

When we switched to `esbuild`, we dropped UMD support, because it doesn't support that natively. This PR brings it back using esbuild's `banner` and `footer` options.

The motivation for this was that TiddlyWiki uses and expects UMD in the browser.

## Test plan (required)

> Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

There's a [test](https://matheus23.files.fission.name/p/webnative-umd/) running webnative in the browser using the UMD build, it works.

I didn't test TiddlyWiki, yet. I've sent @saqimtiaz a message on discord, so he can give me some feedback.

## After Merge
* Make a release

