### PR TITLE
Replace base58-universal dependency with uint8arrays (& add changelog checker)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ jobs:
         uses: Zomzog/changelog-checker@v1.2.0
         with:
           fileName: CHANGELOG.md
-          noChangelogLabel: no changelog
+          noChangelogLabel: "no changelog"
           checksNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,11 @@
 name: Changelog Check
-on: pull_request
+on: 
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build:
     name: Check Actions

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,16 @@
+name: Changelog Check
+on: pull_request
+jobs:
+  build:
+    name: Check Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          noChangelogLabel: no changelog
+          checksNotification: Simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "keystore-idb": "0.14.2",
     "localforage": "^1.9.0",
     "noble-ed25519": "^1.2.4",
-    "throttle-debounce": "^3.0.1"
+    "throttle-debounce": "^3.0.1",
+    "uint8arrays": "^2.1.7"
   },
   "resolutions": {
     "**/ipfs-message-port-protocol": "https://ipfs.runfission.com/ipfs/bafybeigx6q4aezve7my76s5vvfuiinbxtepapqvmjf2jbgrozrut6cjape/p/ipfs-message-port-protocol.tar.gz"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "yarn": "^1.22.4"
   },
   "dependencies": {
-    "base58-universal": "https://github.com/digitalbazaar/base58-universal#de970560f005de0f7054723c35ef6e0ff4b328b7",
     "buffer": "^6.0.3",
     "cborg": "^1.3.4",
     "cids": "^1.1.6",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,4 +1,0 @@
-declare module 'base58-universal' {
-    export function encode(input: Uint8Array, maxline?: number): string
-    export function decode(input: string): Uint8Array
-}

--- a/src/did/transformers.ts
+++ b/src/did/transformers.ts
@@ -1,4 +1,4 @@
-import * as base58 from 'base58-universal'
+import * as uint8arrays from 'uint8arrays'
 import * as utils from 'keystore-idb/utils'
 
 import { BASE58_DID_PREFIX, magicBytes, parseMagicBytes } from './util'
@@ -23,7 +23,7 @@ export function publicKeyToDid(
   const prefixedBuf = utils.joinBufs(prefix, pubKeyBuf)
 
   // Encode prefixed
-  return BASE58_DID_PREFIX + base58.encode(new Uint8Array(prefixedBuf))
+  return BASE58_DID_PREFIX + uint8arrays.toString(new Uint8Array(prefixedBuf), "base58btc")
 }
 
 /**
@@ -38,7 +38,7 @@ export function didToPublicKey(did: string): {
   }
 
   const didWithoutPrefix = did.substr(BASE58_DID_PREFIX.length)
-  const magicalBuf = base58.decode(didWithoutPrefix)
+  const magicalBuf = uint8arrays.fromString(didWithoutPrefix, "base58btc")
   const { keyBuffer, type } = parseMagicBytes(magicalBuf)
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,10 +2226,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-"base58-universal@https://github.com/digitalbazaar/base58-universal#de970560f005de0f7054723c35ef6e0ff4b328b7":
-  version "1.0.1-0"
-  resolved "https://github.com/digitalbazaar/base58-universal#de970560f005de0f7054723c35ef6e0ff4b328b7"
-
 base64-arraybuffer@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz#9818c79e059b1355f97e0428a017c838e90ba812"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6363,6 +6363,11 @@ multiformats@^8.0.3, multiformats@^8.0.6:
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-8.0.6.tgz#af90b9291db70f479ecd6a5583f0ebb07d38e990"
   integrity sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==
 
+multiformats@^9.4.2:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.2.tgz#3995a0b23072657d7a2fa56b2afc745e0ce8e5bd"
+  integrity sha512-GXsulAzqA+EI/iObKWsg9n4PKNVpUTsWdA+Ijn3hJMaVHQ/+dJaClSZ55g8sVKniBjQkouGaVCKCu9c/wwMXQQ==
+
 multihashes@^4.0.1, multihashes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-4.0.2.tgz#d76aeac3a302a1bed9fe1ec964fb7a22fa662283"
@@ -7971,6 +7976,13 @@ uint8arrays@^2.0.5, uint8arrays@^2.1.2, uint8arrays@^2.1.3, uint8arrays@^2.1.4, 
   integrity sha512-CSR7AO+4AHUeSOnZ/NBNCElDeWfRh9bXtOck27083kc7SznmmHIhNEkEOCQOn0wvrIMjS3IH0TNLR16vuc46mA==
   dependencies:
     multibase "^4.0.1"
+
+uint8arrays@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-2.1.7.tgz#16719b54b7b17be66eb9e44698a45f8371750b84"
+  integrity sha512-k+yuEWEHQG/TuRaxL+JVEe8IBqyU5dhDkw+CISCDccOcW90dIju0A6i0Iwav0MK7kg73FZpowqOByS5e/B6GYA==
+  dependencies:
+    multiformats "^9.4.2"
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary

This PR replaces usage of `base58-universal` with `uint8arrays`

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

We depend on a *branch* in the `base58-universal` github repository, instead of on the npm package. This means it has to be built by anyone using webnative (if they use webnative as an npm package). This process can be flaky (#260).

Instead, we can depend on `uint8arrays`, which is a dependency of many of *our* dependencies. E.g. [js-ipfs-core depends on it](https://github.com/ipfs/js-ipfs/blob/dc041aa3de789290bfc5c1c0b8c2878d8c79186a/packages/ipfs-core/package.json#L123).
It makes sense to go with ecosystem momentum here.

## Test plan (required)

> Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

The tests run :white_check_mark: . Only DID parsing/generation are affected by this change, and they're fairly well covered by our tests. The behavior is the same as before.

## After Merge
* Release!
