### PR TITLE
Typedoc Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "node": ">=15"
   },
   "scripts": {
-    "docs": "rimraf docs && typedoc && typedoc --entryPoints ./src/fs --out docs/fs",
+    "docs": "rimraf docs && typedoc",
     "lint": "yarn eslint src/**/*.ts",
     "prebuild": "rimraf lib dist && node scripts/gen-version.js",
     "build": "ttsc && yarn run build:minified && cp src/package.json lib/package.json",
@@ -91,7 +91,7 @@
     "rimraf": "^3.0.2",
     "tslib": "^2.2.0",
     "ttypescript": "^1.5.12",
-    "typedoc": "^0.21.2",
+    "typedoc": "^0.21.4",
     "typescript": "^4.3.2",
     "yarn": "^1.22.4"
   },

--- a/scripts/TYPEDOC.md
+++ b/scripts/TYPEDOC.md
@@ -1,0 +1,30 @@
+# Webnative API Reference
+
+[version](/modules/common_version.html#VERSION)
+
+This is source-derived, auto-generated API reference for [webnative](https://github.com/fission-suite/webnative).
+
+If you need an introduction to webnative, we recommend reading the [fission guide](https://guide.fission.codes/developers/webnative) instead. This document is meant to be used as API reference.
+
+## Which Docs to Look At
+
+When you import webnative like this:
+```js
+import * as webnative from "webnative"
+```
+
+or like this:
+
+```js
+const webnative = require("webnative")
+```
+
+or using a script tag:
+```html
+<script src="https://unpkg.com/webnative@latest/dist/index.umd.min.js">
+```
+
+Then you'll have a `webnative` variable at disposal which contains the [`index` module](/modules/index.html).
+
+Once you've loaded a filesystem, you'll have an instance of the [`FileSystem` class](/classes/fs_filesystem.FileSystem.html). Read its docs to see what filesystem operations are supported.
+

--- a/scripts/TYPEDOC.md
+++ b/scripts/TYPEDOC.md
@@ -1,10 +1,10 @@
 # Webnative API Reference
 
-[version](/modules/common_version.html#VERSION)
+[version](./modules/common_version.html#VERSION)
 
-This is source-derived, auto-generated API reference for [webnative](https://github.com/fission-suite/webnative).
+This is the source-derived, auto-generated API reference for [webnative](https://github.com/fission-suite/webnative).
 
-If you need an introduction to webnative, we recommend reading the [fission guide](https://guide.fission.codes/developers/webnative) instead. This document is meant to be used as API reference.
+If you need an introduction to webnative, we recommend reading the [fission guide](https://guide.fission.codes/developers/webnative) instead. This document is meant to be used as an API reference.
 
 
 ## Which Docs to Look At
@@ -25,19 +25,13 @@ or using a script tag:
 <script src="https://unpkg.com/webnative@latest/dist/index.umd.min.js">
 ```
 
-Then you'll have a `webnative` variable at disposal which contains the [`index` module](/modules/index.html).
+Then you'll have a `webnative` variable at disposal which contains the [`index` module](./modules/index.html).
 
-Once you've loaded a filesystem, you'll have an instance of the [`FileSystem` class](/classes/fs_filesystem.FileSystem.html). Read its docs to see what filesystem operations are supported.
+Once you've loaded a filesystem, you'll have an instance of the [`FileSystem` class](./classes/fs_filesystem.FileSystem.html). Read its docs to see what filesystem operations are supported.
 
 
 ## These Docs for another Webnative Version
 
 The docs at [webnative.fission.app](https://webnative.fission.app) will always be the docs for the most recent webnative version.
 
-If you want to look at the docs for an older webnative version, keep in mind that webnative's npm package ships with these docs at`node_modules/webnative/docs/`. So if you want to take a look at them, you can start your own local http server:
-
-```sh
-$ npm i -D http-server
-$ npx http-server ./node_modules/webnative/docs
-# open localhost:8080
-```
+If you want to look at the docs for an older webnative version, keep in mind that webnative's npm package ships with these docs at`node_modules/webnative/docs/`. So if you want to take a look at them, just open these docs' html files (at `./node_modules/webnative/docs/index.html`) in your browser.

--- a/scripts/TYPEDOC.md
+++ b/scripts/TYPEDOC.md
@@ -6,6 +6,7 @@ This is source-derived, auto-generated API reference for [webnative](https://git
 
 If you need an introduction to webnative, we recommend reading the [fission guide](https://guide.fission.codes/developers/webnative) instead. This document is meant to be used as API reference.
 
+
 ## Which Docs to Look At
 
 When you import webnative like this:
@@ -28,3 +29,15 @@ Then you'll have a `webnative` variable at disposal which contains the [`index` 
 
 Once you've loaded a filesystem, you'll have an instance of the [`FileSystem` class](/classes/fs_filesystem.FileSystem.html). Read its docs to see what filesystem operations are supported.
 
+
+## These Docs for another Webnative Version
+
+The docs at [webnative.fission.app](https://webnative.fission.app) will always be the docs for the most recent webnative version.
+
+If you want to look at the docs for an older webnative version, keep in mind that webnative's npm package ships with these docs at`node_modules/webnative/docs/`. So if you want to take a look at them, you can start your own local http server:
+
+```sh
+$ npm i -D http-server
+$ npx http-server ./node_modules/webnative/docs
+# open localhost:8080
+```

--- a/src/fs/base/file.ts
+++ b/src/fs/base/file.ts
@@ -1,6 +1,4 @@
 /** @internal */
-
-/** @internal */
 import { File } from '../types'
 import { AddResult, CID, FileContent } from '../../ipfs/index'
 

--- a/src/fs/protocol/public/index.ts
+++ b/src/fs/protocol/public/index.ts
@@ -1,6 +1,4 @@
 /** @internal */
-
-/** @internal */
 import { Link, Links } from '../../types'
 import { TreeInfo, FileInfo, Skeleton, PutDetails } from './types'
 import { Metadata } from '../../metadata'

--- a/src/fs/types/check.ts
+++ b/src/fs/types/check.ts
@@ -1,6 +1,4 @@
 /** @internal */
-
-/** @internal */
 import { isString, isObject, isNum, isBool } from '../../common/index'
 import { CID } from '../../ipfs/index'
 import { Tree, File, Link, Links, BaseLink } from '../types'

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,10 +1,12 @@
 {
-  "entryPoints": [ "./src/index.ts" ],
+  "entryPoints": [ "./src/" ],
+  "exclude": "**/*.test.ts",
   "excludeExternals": true,
   "excludeInternal": true,
   "excludePrivate": true,
   "excludeProtected": true,
   "name": "Fission SDK",
   "out": "docs",
-  "readme": "none"
+  "readme": "./scripts/TYPEDOC.md",
+  "highlightTheme": "github-light"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,6 +1936,11 @@ acorn@^8.2.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.4.tgz#caba24b08185c3b56e3168e97d15ed17f4d31fd0"
   integrity sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==
 
+aegir-typedoc-theme@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/aegir-typedoc-theme/-/aegir-typedoc-theme-0.1.0.tgz#0f5164ad9fc1be2c19b88997004750b54ddde35a"
+  integrity sha512-R7AWc1Q6bHozUNLljXwSIO4sTvVl/JNGOW5s2ZLwoqiZxQMyB1EMTL1MRpXtxJEhOgKrhzf9XR5R8J3g/Kjhow==
+
 after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
@@ -7927,14 +7932,13 @@ typedoc-default-themes@^0.12.10:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
   integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
 
-typedoc@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.2.tgz#cf5094314d3d63e95a8ef052ceff06a6cafd509d"
-  integrity sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==
+typedoc@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.4.tgz#fced3cffdc30180db60a5dbfec9dbbb273cb5b31"
+  integrity sha512-slZQhvD9U0d9KacktYAyuNMMOXJRFNHy+Gd8xY2Qrqq3eTTTv3frv3N4au/cFnab9t3T5WA0Orb6QUjMc+1bDA==
   dependencies:
     glob "^7.1.7"
     handlebars "^4.7.7"
-    lodash "^4.17.21"
     lunr "^2.3.9"
     marked "^2.1.1"
     minimatch "^3.0.0"


### PR DESCRIPTION
## Summary

Some typedoc improvements: There's now a root 'readme' for the typedocs, and we're only running typedoc once and configured it slightly differently.

> Explain the **motivation** for making this change. What existing problem does the pull request solve?

Our typedocs previously weren't linked to each other correctly. So e.g. I wouldn't be able to take a look at the `FileContent` type when I was inside the `FileSystem` class. Also there were no links to `FileSystem` form the root of the docs, you'd have to know about `webnative.fission.app/fs`. 

## Test plan (required)

Hm. Ideally I want the docs to be rendered in github actions, but for that I'd need access to the fission account that belongs to `webnative.fission.app` (I think you have that @icidasset?).
