### PR TITLE
Add namefilter tests

### DIFF
--- a/src/fs/protocol/private/namefilter.test.ts
+++ b/src/fs/protocol/private/namefilter.test.ts
@@ -1,0 +1,125 @@
+import * as fc from "fast-check"
+import expect from "expect"
+
+import { BloomFilter } from "fission-bloom-filters"
+
+import * as namefilter from "./namefilter.js"
+
+
+describe("hex bloom filter conversion", () => {
+
+  before(() => {
+    fc.configureGlobal({ numRuns: 10000 })
+  })
+
+  after(() => {
+    fc.resetConfigureGlobal()
+  })
+
+  /** Round trip hex to bloom filter
+   * The bloom filter implementation likely drops the last digit of odd-length hex strings
+   * because the last digit would only encode half a byte. We therefore only test even-length
+   * hex strings here.
+   */
+  it("round trip hex to bloom filter", async () => {
+    fc.assert(
+      fc.property(fc.hexaString({ minLength: 2 }).filter(str => str.length % 2 == 0), originalHex => {
+        const filter = namefilter.fromHex(originalHex)
+        const returnHex = namefilter.toHex(filter)
+        expect(returnHex).toBe(originalHex)
+      })
+    )
+  })
+})
+
+describe("bare filters", () => {
+  it("a new filter with one entry has 16 bits set", async () => {
+    fc.assert(
+      fc.asyncProperty(fc.string({ minLength: 1 }), async key => {
+        const filter = await namefilter.createBare(key)
+
+        const bloomFilter = namefilter.fromHex(filter)
+        const onesCount = countOnes(bloomFilter)
+        expect(onesCount).toEqual(16)
+      })
+    )
+  })
+
+  it("a filter with two entries has between 16 and 32 bits set", async () => {
+    fc.assert(
+      fc.asyncProperty(fc.tuple(
+        fc.string({ minLength: 1 }),
+        fc.string({ minLength: 1 })
+      ), async ([first, second]) => {
+        let filter = await namefilter.createBare(first)
+        filter = await namefilter.addToBare(filter, second)
+
+        const bloomFilter = namefilter.fromHex(filter)
+        const onesCount = countOnes(bloomFilter)
+        expect(onesCount).toBeGreaterThanOrEqual(16)
+        expect(onesCount).toBeLessThanOrEqual(32)
+      })
+    )
+  })
+
+  it("a filter with n entries has between 16 and n*16 bits set", async () => {
+    fc.assert(
+      fc.asyncProperty(fc.array(
+        fc.string({ minLength: 1 }), { minLength: 1, maxLength: 40 }
+      ), async keys => {
+        const n = keys.length
+
+        let filter = await namefilter.createBare(keys[0])
+        keys.slice(1).forEach(async key => {
+          filter = await namefilter.addToBare(filter, key)
+        })
+
+        const bloomFilter = namefilter.fromHex(filter)
+        const onesCount = countOnes(bloomFilter)
+        expect(onesCount).toBeGreaterThanOrEqual(16)
+        expect(onesCount).toBeLessThanOrEqual(n * 16)
+      })
+    )
+  })
+})
+
+describe("revision filters", () => {
+  it("add revision adds one entry", async () => {
+    fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 1 }),
+        fc.integer({ min: 1 }),
+        async (key, revision) => {
+          const filter = await namefilter.createBare(key)
+          const revisionFilter = await namefilter.addRevision(filter, key, revision)
+
+          const bloomFilter = namefilter.fromHex(revisionFilter)
+          const onesCount = countOnes(bloomFilter)
+          expect(onesCount).toBeGreaterThanOrEqual(16)
+          expect(onesCount).toBeLessThanOrEqual(32)
+        })
+    )
+  })
+})
+
+/** Helper functions
+ * These helper functions MUST match the implementations in namefilter.ts!
+ */
+
+// count the number of 1 bits in a filter
+const countOnes = (filter: BloomFilter): number => {
+  const arr = new Uint32Array(filter.toBytes())
+  let count = 0
+  for (let i = 0; i < arr.length; i++) {
+    count += bitCount32(arr[i])
+  }
+  return count
+}
+
+// counts the number of 1s in a uint32
+// from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+const bitCount32 = (num: number): number => {
+  const a = num - ((num >> 1) & 0x55555555)
+  const b = (a & 0x33333333) + ((a >> 2) & 0x33333333)
+  return ((b + (b >> 4) & 0xF0F0F0F) * 0x1010101) >> 24
+}

--- a/tests/fs/api.private.node.test.ts
+++ b/tests/fs/api.private.node.test.ts
@@ -13,18 +13,18 @@ import { emptyFilesystem } from "../helpers/filesystem.js"
 import { privateFileContent as fileContent, privateDecode as decode } from "../helpers/fileContent.js"
 
 
-fc.configureGlobal(process.env.TEST_ENV === "gh-action" ? { numRuns: 50 } : { numRuns: 10 })
-
 describe("the private filesystem api", function () {
 
   let ipfs: IPFS | null = null
 
   before(async function () {
+    fc.configureGlobal(process.env.TEST_ENV === "gh-action" ? { numRuns: 50 } : { numRuns: 10 })
     ipfs = await createInMemoryIPFS()
     ipfsConfig.set(ipfs)
   })
 
   after(async () => {
+    fc.resetConfigureGlobal()
     if (ipfs === null) return
     await ipfs.stop()
   })

--- a/tests/fs/api.public.node.test.ts
+++ b/tests/fs/api.public.node.test.ts
@@ -13,18 +13,18 @@ import { emptyFilesystem } from "../helpers/filesystem.js"
 import { publicFileContent as fileContent, publicDecode as decode } from "../helpers/fileContent.js"
 
 
-fc.configureGlobal(process.env.TEST_ENV === "gh-action" ? { numRuns: 50 } : { numRuns: 10 })
-
 describe("the public filesystem api", function () {
 
   let ipfs: IPFS | null = null
 
   before(async function () {
+    fc.configureGlobal(process.env.TEST_ENV === "gh-action" ? { numRuns: 50 } : { numRuns: 10 })
     ipfs = await createInMemoryIPFS()
     ipfsConfig.set(ipfs)
   })
 
   after(async () => {
+    fc.resetConfigureGlobal()
     if (ipfs === null) return
     await ipfs.stop()
   })


### PR DESCRIPTION
## Summary

This PR adds an initial set of tests of the namefilter implementation used in the private filesystem.

This PR fixes/implements the following **bugs/features**

* [x] Add hex to bloom filter conversion tests
* [x] Add bare filter bit count tests
* [x] Add revision filter test

We run each test 10,000 times because they are fast and they finish before some of our other longer running tests.

## Test plan (required)

The new tests should pass in the GH action and can also be run in isolation with
 
```
yarn test --grep "filter"
```

All tests should pass.