### PR TITLE
Add extra lobby params

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -50,10 +50,14 @@ export async function leave({ withoutRedirect }: { withoutRedirect?: boolean } =
  *                    Pass `null` if working without permissions.
  * @param redirectTo Specify the URL you want users to return to.
  *                   Uses the current url by default.
+ * @param extraLobbyParams Extra parameters object. Properties on the
+ *                         object are converted to query params and sent
+ *                         to the auth lobby.
  */
 export async function redirectToLobby(
   permissions: Maybe<Permissions>,
-  redirectTo?: string
+  redirectTo?: string,
+  extraLobbyParams?: Record<string, string>
 ): Promise<void> {
   const app = permissions?.app
   const fs = permissions?.fs
@@ -75,10 +79,11 @@ export async function redirectToLobby(
     [ "sharedRepo", sharedRepo ? "t" : "f" ]
 
   ].concat(
-    app           ? [[ "appFolder", `${app.creator}/${app.name}` ]] : [],
-    fs?.private   ? fs.private.map(p => [ "privatePath", path.toPosix(p, { absolute: true }) ]) : [],
-    fs?.public    ? fs.public.map(p => [ "publicPath", path.toPosix(p, { absolute: true }) ]) : [],
-    raw           ? [["raw", base64.urlEncode(JSON.stringify(raw))]]  : []
+    app              ? [[ "appFolder", `${app.creator}/${app.name}` ]] : [],
+    fs?.private      ? fs.private.map(p => [ "privatePath", path.toPosix(p, { absolute: true }) ]) : [],
+    fs?.public       ? fs.public.map(p => [ "publicPath", path.toPosix(p, { absolute: true }) ]) : [],
+    raw              ? [["raw", base64.urlEncode(JSON.stringify(raw))]]  : [],
+    extraLobbyParams ? Object.entries(extraLobbyParams)  : []
 
   ).concat((() => {
     const apps = platform?.apps


### PR DESCRIPTION
## Summary

This PR adds an `extraLobbyParams` parameter to `redirectToLobby`. The properties on `extraLobbyParams` get converted into query params and sent to the auth lobby.

This PR fixes/implements the following **features**

* [x] Add `extraLobbyParams` to `redirectToLobby`

Initially, `extraLobbyParams` is intended for use with theming (https://github.com/fission-suite/auth-lobby#theming), but it could be used for other purposes in the future.

**Note:** In this implementation, a user must pass something to `redirectToLobby` for `permissions` and `redirectTo` in order to use `extraLobbyParams`. For example:

```
wn.redirectToLobby(state.permissions, window.location.href, { theme: <CID> })
``` 
In a future release, we could pass a single object to `redirectToLobby` with `permissions`, `redirectTo`, and any additional parameters.

## Test plan (required)

Calling `redirectToLobby` with `extraLobbyParams` should add query params to the redirect URL. For example:
```
wn.redirectToLobby(state.permissions, window.location.href, { dogs: "yes", cats: "yes"})
```
Would append `&dogs=yes&cats=yes` to the URL.

An empty `extraLobbyParams` object should not add additional query params.

Calling `redirectToLobby` with only `permissions` or `permissions` and `redirectTo` should work like normal and not add additional query params.

## Closing issues

Closes #271 

## After Merge

* [x] Does this change invalidate any docs or tutorials? It does not invalidate, but we can add a theming section to the guide! :paintbrush: :art: 
* [ ] Does this change require a release to be made? Is so please create and deploy the release

