### PR TITLE
Fixes #272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v0.27
+
+Fixed `webnative.apps.index()`, and now returns a list of domains, along with their `insertedAt` and `modifiedAt` ISO8601 timestamps.
+
+
+
 ### v0.26.2
 
 - Add `extraLobbyParams` to `redirectToLobby`. Extra lobby params are transformed into query params that may be read by the auth lobby. (#273)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.27
+### v0.27.0
 
 Fixed `webnative.apps.index()`, and now returns a list of domains, along with their `insertedAt` and `modifiedAt` ISO8601 timestamps.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/apps/index.ts
+++ b/src/apps/index.ts
@@ -6,8 +6,8 @@ import { CID } from "../ipfs/index.js"
 
 
 export type App = {
-  domains: string[],
-  insertedAt: string,
+  domains: string[]
+  insertedAt: string
   modifiedAt: string
 }
 
@@ -40,8 +40,8 @@ export async function index(): Promise<Array<App>> {
 
   const data: {
     [k: number]: {
-      insertedAt: string,
-      modifiedAt: string,
+      insertedAt: string
+      modifiedAt: string
       urls: string[]
     }
   } = await response.json()


### PR DESCRIPTION
The server format has changed, this PR updates the expected format.
Now returns a list of domains, and also the `insertedAt` and `modifiedAt` ISO8601 timestamps.


## Test plan (required)

Tested with this branch of the dashboard (required a few minor changes):
https://github.com/fission-suite/dashboard/compare/icidasset/app-index?expand=1

