### PR TITLE
Add eslint rule @typescript-eslint/no-hanging-promises to prevent not awaiting fast check assertions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,9 @@
 module.exports = {
   root: true,
   parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: `./tsconfig.eslint.json`
+  },
   plugins: [
     "@typescript-eslint",
   ],
@@ -21,6 +24,8 @@ module.exports = {
     "@typescript-eslint/ban-ts-comment": 1,
     "@typescript-eslint/quotes": ["error", "double", {
       allowTemplateLiterals: true
-    }]
+    }],
+    // If you want to *intentionally* run a promise without awaiting, prepend it with "void " instead of "await "
+    "@typescript-eslint/no-floating-promises": ["error"],
   }
 }

--- a/src/common/async.node.test.ts
+++ b/src/common/async.node.test.ts
@@ -4,8 +4,8 @@ import { race } from "./async.js"
 
 describe("async race", () => {
 
-  it("returns a promise that was passed into it", () => {
-    fc.assert(
+  it("returns a promise that was passed into it", async () => {
+    await fc.assert(
       fc.asyncProperty(
         fc.array(fc.integer()), async data => {
           const asyncFuncs = data.map(async num => {

--- a/src/common/util.node.test.ts
+++ b/src/common/util.node.test.ts
@@ -66,25 +66,25 @@ describe("async maps over an object", () => {
   it("adds one to each entry in an object", async () => {
     const obj = { a: 1, b: 2, c: 3 }
     async function addOne(val: number, key: string) { return val + 1 }
-    expect(util.mapObjAsync(obj, addOne)).resolves.toEqual({ a: 2, b: 3, c: 4 })
+    expect(await util.mapObjAsync(obj, addOne)).toEqual({ a: 2, b: 3, c: 4 })
   })
 
   it("nullifies each entry in an object", async () => {
     const obj = { a: 1, b: 2, c: 3 }
     async function nullify(val: number, key: string) { return null }
-    expect(util.mapObjAsync(obj, nullify)).resolves.toEqual({ a: null, b: null, c: null })
+    expect(await util.mapObjAsync(obj, nullify)).toEqual({ a: null, b: null, c: null })
   })
 
   it("has no effect on an empty object", async () => {
     const obj = {}
     async function nullify(val: number, key: string) { return null }
-    expect(util.mapObjAsync(obj, nullify)).resolves.toEqual({})
+    expect(await util.mapObjAsync(obj, nullify)).toEqual({})
   })
 
   it("sets each entries value to its key", async () => {
     const obj = { a: 1, b: 2 }
     async function setToKey(val: number, key: string) { return key }
-    expect(util.mapObjAsync(obj, setToKey)).resolves.toEqual({ a: "a", b: "b" })
+    expect(await util.mapObjAsync(obj, setToKey)).toEqual({ a: "a", b: "b" })
   })
 })
 
@@ -110,17 +110,17 @@ describe("async waterfall", () => {
     async function addOne(val: number) { return val + 1 }
     async function addTwo(val: number) { return val + 2 }
     async function addThree(val: number) { return val + 3 }
-    expect(util.asyncWaterfall(0, [addOne, addTwo, addThree])).resolves.toEqual(6)
+    expect(await util.asyncWaterfall(0, [addOne, addTwo, addThree])).toEqual(6)
   })
 
   it("concatenates characters returned from async calls", async () => {
     async function concatB(val: string) { return val + "b" }
     async function concatC(val: string) { return val + "c" }
     async function concatD(val: string) { return val + "d" }
-    expect(util.asyncWaterfall("a", [concatB, concatC, concatD])).resolves.toEqual("abcd")
+    expect(await util.asyncWaterfall("a", [concatB, concatC, concatD])).toEqual("abcd")
   })
 
   it("returns the initial value when no waterfall", async () => {
-    expect(util.asyncWaterfall(0, [])).resolves.toEqual(0)
+    expect(await util.asyncWaterfall(0, [])).toEqual(0)
   })
 })

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -96,8 +96,8 @@ export class FileSystem {
 
     // Add the root CID of the file system to the CID log
     // (reverse list, newest cid first)
-    const logCid = (cid: CID) => {
-      cidLog.add(cid)
+    const logCid = async (cid: CID) => {
+      await cidLog.add(cid)
       debug.log("📓 Adding to the CID ledger:", cid)
     }
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
I recently wrote a test case in another branch that didn't await the fast-check assertion:

```ts
it("has some asynchronous property", async () => {
  fc.assert(fc.asyncProperty(...))
}
```
But that' won't actually fail if the property fails. In fact it returns almost immediately (synchronously). So it doesn't think there's anything going wrong in the test, it just runs.

The correct version is this:
```ts
it("has some asynchronous property", async () => {
  await fc.assert(fc.asyncProperty(...))
}
```

I was so shocked at how dangerous this is that I decided to look for a rule preventing this.

There *are* use cases for having hanging promises, e.g. if you want to intentionally run an asynchronous action. In these cases, prepend your hanging promise with `void` like you'd do it with `await`:

```ts
async function hugeComputationWithSideEffect(n: number): Promise<void>

// usage:
void hugeComputationWithSideEffect(0) // hanging promise
void hugeComputationWithSideEffect(1) // hanging promise
```
