### PR TITLE
Improve login flow resilience against extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.27.1
+
+- Made the login low more resilient. Should work better with extensions triggering `postMessage`s now.
+
+
 ### v0.27.0
 
 - Fixed `webnative.apps.index()`, and now returns a list of domains, along with their `insertedAt` and `modifiedAt` ISO8601 timestamps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.27.0"
+export const VERSION = "0.27.1"


### PR DESCRIPTION
This happens to me from time to time when logging in with fission apps:
![image](https://user-images.githubusercontent.com/1430958/131826566-0b8394ee-230d-454a-83e2-cb846e90d126.png)

I identified the cause of this issue to be my "10ten" extension. It would `postMessage` from the `auth.fission.codes` origin with a message like `10ten(X)ping`.

Webnative would think that a message from the auth lobby must be login info and try to parse that as JSON.

I should've really thought of the whole `postMessage` thing like a distributed system. We just don't know anything about the messages we're getting.

So, the assumptions I'm making now is that we won't get more than 9 unrelated messages and we'll the message we care about within 10 seconds.

With the 10ten extension enabled, I don't have any problems logging in anymore.