### PR TITLE
Auto-publish docs on release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - 'releases/**'
+      - '!releases/**-alpha'
+
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Install Dependencies
+        run: yarn install --network-concurrency 1
+
+      - name: Generate docs
+        run: yarn run docs
+        
+      - name: Publish to Fission
+        uses: fission-suite/publish-action@v1
+        with:
+          machine_key: ${{ secrets.FISSION_PRODUCTION_KEY }}
+          build_dir: ./docs
+          app_url: webnative.fission.app

--- a/fission.yaml
+++ b/fission.yaml
@@ -1,3 +1,0 @@
-ignore: []
-url: webnative.fission.app
-build: ./docs


### PR DESCRIPTION
This'll deploy the docs to https://webnative.fission.app when a non-alpha release is made.

Info about 'releases' glob pattern:
https://docs.github.com/en/enterprise-server@2.22/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns

Closes #175