### PR TITLE
Add versioned API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.28.2
+
+- Update API endpoints to v2 and add setup parameter to specify API version
+
+
 ### v0.28.1
 
 - Fixed bundling issues with older bundlers, ie. bundlers that did not yet support the `exports` map in `package.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/apps/index.ts
+++ b/src/apps/index.ts
@@ -24,7 +24,7 @@ type AppIndexResponseJson = {
  * Get A list of all of your apps and their associated domain names
  */
 export async function index(): Promise<Array<App>> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   const localUcan = await ucan.dictionary.lookupAppUcan("*")
   if (localUcan === null) {
@@ -61,7 +61,7 @@ export async function index(): Promise<Array<App>> {
 export async function create(
   subdomain: Maybe<string>
 ): Promise<App> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   const localUcan = await ucan.dictionary.lookupAppUcan("*")
   if (localUcan === null) {
@@ -104,7 +104,7 @@ export async function create(
 export async function deleteByDomain(
   domain: string
 ): Promise<void> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   const localUcan = await ucan.dictionary.lookupAppUcan(domain)
   if (localUcan === null) {
@@ -148,7 +148,7 @@ export async function publish(
   domain: string,
   cid: CID,
 ): Promise<void> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   const localUcan = await ucan.dictionary.lookupAppUcan(domain)
   if (localUcan === null) {
@@ -165,7 +165,7 @@ export async function publish(
   const url = `${apiEndpoint}/app/${domain}/${cid}`
 
   await fetch(url, {
-    method: "PATCH",
+    method: "PUT",
     headers: {
       "authorization": `Bearer ${jwt}`
     }

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.28.1"
+export const VERSION = "0.28.2"

--- a/src/data-root.ts
+++ b/src/data-root.ts
@@ -44,9 +44,11 @@ export async function lookup(
 export async function lookupOnFisson(
   username: string
 ): Promise<CID | null> {
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
+
   try {
     const resp = await fetch(
-      `${setup.endpoints.api}/user/data/${username}`,
+      `${apiEndpoint}/user/data/${username}`,
       { cache: "reload" } // don't use cache
     )
     const cid = await resp.json()
@@ -72,7 +74,7 @@ export async function update(
   cid: CID | string,
   proof: string
 ): Promise<{ success: boolean }> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   // Debug
   debug.log("🌊 Updating your DNSLink:", cid)
@@ -98,7 +100,7 @@ export async function update(
     retryOn: [ 502, 503, 504 ],
 
   }, {
-    method: "PATCH"
+    method: "PUT"
 
   }).then((response: Response) => {
     if (response.status < 300) debug.log("🪴 DNSLink updated:", cid)

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -17,7 +17,7 @@ export async function createAccount(
     username: string
   }
 ): Promise<{ success: boolean }> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   const jwt = ucan.encode(await ucan.build({
     audience: await api.did(),
@@ -46,7 +46,7 @@ export async function createAccount(
  * Throws if the user is not logged in.
  */
 export async function resendVerificationEmail(): Promise<{ success: boolean }> {
-  const apiEndpoint = setup.endpoints.api
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
 
   // We've not implemented an "administer account" resource/ucan, so authenticating
   // with any kind of ucan will work server-side

--- a/src/lobby/username.ts
+++ b/src/lobby/username.ts
@@ -8,7 +8,9 @@ import { USERNAME_BLOCKLIST } from "./blocklist.js"
 export async function isUsernameAvailable(
   username: string
 ): Promise<boolean> {
-  const resp = await fetch(`${setup.endpoints.api}/user/data/${username}`)
+  const apiEndpoint = `${setup.endpoints.api}/${setup.endpoints.apiVersion}/api`
+
+  const resp = await fetch(`${apiEndpoint}/user/data/${username}`)
   return !resp.ok
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -29,6 +29,8 @@ export function shouldPin({ enabled }: { enabled: boolean }): boolean {
  *
  * `api` Location of the Fission API
  *       (default `https://runfission.com`)
+ * `apiVersion` Vesion of the Fission API
+ *       (defaults to the latest version)
  * `lobby` Location of the authentication lobby.
  *         (default `https://auth.fission.codes`)
  * `user`  User's domain to use, will be prefixed by username.

--- a/src/setup/internal.ts
+++ b/src/setup/internal.ts
@@ -1,5 +1,6 @@
 export type Endpoints = {
   api: string
+  apiVersion: string
   lobby: string
   user: string
 }
@@ -13,6 +14,7 @@ export const setup = {
 
   endpoints: {
     api: "https://runfission.com",
+    apiVersion: "v2",
     lobby: "https://auth.fission.codes",
     user: "fission.name"
   },


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add `apiVersion` setup param
* [x] Upgrade API version to `v2`

The server has added versioned endpoints. This PR updates calls to the API endpoint and adds an `apiVersion` setup param to configure which API version to use.

The default `apiVersion` is set to `v2` (the latest version) and all existing apps will use this since none have set `apiVersion` yet. This change should be possible without breaking any existing apps.

This PR also upgrades the API endpoints to use `v2` by setting the default `apiVersion` and updating two `PATCH` methods to `PUT`. See https://runfission.com/v2/docs/ for the `v2` API.

## Test plan (required)

All tests are passing, and I tested these changes with React TodoMVC and the Auth Lobby by creating a new user and interacting with WNFS.

## After Merge
* [ ] Does this change invalidate any docs or tutorials? Added a comment for `apiVersion` param, docs should update automatically I think
* [ ] Does this change require a release to be made? Yes

