### PR TITLE
Add soft links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - Make full API URL configurable (not just API host).
 - Fix version checking failing on old filesystems which are missing a `version` tag.
 
+### v0.30.0
+
+Adds soft/symbolic links.
+
+
+
 ### v0.29.1
 
 - Check the wnfs version field when initialising a filesystem and alert users about outdated filesystems or outdated apps.
@@ -22,6 +28,7 @@
 - Upgrade js-ipfs libraries to the versions corresponding to the 0.58 release.
 - Update API endpoints to v2 and add setup parameter to specify API version.
 - No longer uses `ipfs-message-port-client` and `ipfs-message-port-protocol` forks which sometimes caused weird dependency conflicts.
+
 
 
 ### v0.28.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
 # Changelog
-### v0.30.0-alpha2
+
+### v0.30.0
 
 - **WNFS BREAKING CHANGE**: Encrypt the filesystem using AES-GCM instead of AES-CTR. Also wrap the filesystem blocks with some information about the encryption algorithm used.
   Users need to migrate their filesystems to be able to load apps with this webnative version.
   Apps need to update to this webnative version to load migrated/new filesystems.
+- Adds soft/symbolic links.
+
+
 
 ### v0.29.2
 
 - Make webnative work across more environments and bundlers (upgrade one-webcrypto to 1.0.3)
 - Make full API URL configurable (not just API host).
 - Fix version checking failing on old filesystems which are missing a `version` tag.
-
-### v0.30.0
-
-Adds soft/symbolic links.
-
 
 
 ### v0.29.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.30.0-alpha3",
+  "version": "0.30.0-alpha4",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/type-checks.ts
+++ b/src/common/type-checks.ts
@@ -1,3 +1,7 @@
+export function hasProp<K extends PropertyKey>(data: unknown, prop: K): data is Record<K, unknown> {
+  return typeof data === "object" && data != null && prop in data
+}
+
 export const isDefined = <T>(val: T | undefined): val is T => {
   return val !== undefined
 }

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.30.0-alpha3"
+export const VERSION = "0.30.0-alpha4"

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -96,9 +96,14 @@ export async function loadFileSystem(
 
 
 export async function checkVersion(filesystemCID: CID): Promise<void> {
-  const links = await protocol.basic.getLinks(filesystemCID)
-  // if there's no version link, we assume it's from a 1.0.0-comatible version (from before ~ November 2020)
-  const versionStr = links[Branch.Version] == null ? "1.0.0" : new TextDecoder().decode(await protocol.basic.getFile(links[Branch.Version].cid))
+  const links = await protocol.basic.getSimpleLinks(filesystemCID)
+  // if there's no version link, we assume it's from a 1.0.0-compatible version
+  // (from before ~ November 2020)
+  const versionStr = links[Branch.Version] == null
+    ? "1.0.0"
+    : new TextDecoder().decode(
+        await protocol.basic.getFile(links[Branch.Version].cid)
+      )
 
   if (versionStr !== versions.toString(versions.latest)) {
     const versionParsed = versions.fromString(versionStr)

--- a/src/fs/base/file.ts
+++ b/src/fs/base/file.ts
@@ -6,9 +6,11 @@ import { AddResult, CID, FileContent } from "../../ipfs/index.js"
 export abstract class BaseFile implements File {
 
   content: FileContent
+  readOnly: boolean
 
   constructor(content: FileContent) {
     this.content = content
+    this.readOnly = false
   }
 
   async put(): Promise<CID> {
@@ -17,6 +19,7 @@ export abstract class BaseFile implements File {
   }
 
   async updateContent(content: FileContent): Promise<this> {
+    if (this.readOnly) throw new Error("File is read-only")
     this.content = content
     return this
   }

--- a/src/fs/link.ts
+++ b/src/fs/link.ts
@@ -1,8 +1,7 @@
 import dagPb, { DAGLink } from "ipld-dag-pb"
 import type { IPFSEntry } from "ipfs-core-types/src/root"
 
-import { Link, SimpleLink } from "./types.js"
-import { mtimeFromMs } from "./metadata.js"
+import { HardLink, SimpleLink } from "./types.js"
 
 
 export const toDAGLink = (link: SimpleLink): DAGLink => {
@@ -10,13 +9,12 @@ export const toDAGLink = (link: SimpleLink): DAGLink => {
   return new dagPb.DAGLink(name, size, cid)
 }
 
-export const fromFSFile = (fsObj: IPFSEntry): Link => {
-  const { name = "", cid, size, mtime, type } = fsObj
+export const fromFSFile = (fsObj: IPFSEntry): HardLink => {
+  const { name = "", cid, size, type } = fsObj
   return {
     name,
     cid: cid.toString(),
     size,
-    mtime,
     isFile: type !== "dir"
   }
 }
@@ -28,13 +26,12 @@ export const fromDAGLink = (link: DAGLink): SimpleLink => {
   return { name, cid, size }
 }
 
-export const make = (name: string, cid: string, isFile: boolean, size: number): Link => {
+export const make = (name: string, cid: string, isFile: boolean, size: number): HardLink => {
   return {
     name,
     cid,
     size,
-    isFile,
-    mtime: mtimeFromMs(Date.now())
+    isFile
   }
 }
 

--- a/src/fs/protocol/private/index.ts
+++ b/src/fs/protocol/private/index.ts
@@ -45,7 +45,7 @@ export const getByCID = async (cid: CID, key: string): Promise<DecryptedNode> =>
   return await readNode(cid, key)
 }
 
-export const getByLatestName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
+export const getLatestByName = async (mmpt: MMPT, name: PrivateName, key: string): Promise<Maybe<DecryptedNode>> => {
   const cid = await mmpt.get(name)
   if (cid === null) return null
   return getLatestByCID(mmpt, cid, key)
@@ -59,10 +59,10 @@ export const getLatestByCID = async (mmpt: MMPT, cid: CID, key: string): Promise
     : node
 }
 
-export const getLatestByBareNameFilter = async(mmpt: MMPT, bareName: BareNameFilter, key:string): Promise<Maybe<DecryptedNode>> => {
+export const getLatestByBareNameFilter = async(mmpt: MMPT, bareName: BareNameFilter, key: string): Promise<Maybe<DecryptedNode>> => {
   const revisionFilter = await namefilter.addRevision(bareName, key, 1)
   const name = await namefilter.toPrivateName(revisionFilter)
-  return getByLatestName(mmpt, name, key)
+  return getLatestByName(mmpt, name, key)
 }
 
 export const findLatestRevision = async (mmpt: MMPT, bareName: BareNameFilter, key: string, lastKnownRevision: number): Promise<Maybe<Revision>> => {

--- a/src/fs/protocol/private/types.ts
+++ b/src/fs/protocol/private/types.ts
@@ -1,4 +1,4 @@
-import { BaseLink } from "../../types.js"
+import { BaseLink, SoftLink } from "../../types.js"
 import  { Metadata } from "../../metadata.js"
 import { AddResult, CID } from "../../../ipfs/index.js"
 import { BareNameFilter, PrivateName } from "./namefilter.js"
@@ -18,7 +18,7 @@ export type PrivateLink = BaseLink & {
   pointer: PrivateName
 }
 
-export type PrivateLinks = { [name: string]: PrivateLink }
+export type PrivateLinks = { [name: string]: PrivateLink | SoftLink }
 
 export type PrivateTreeInfo = {
   metadata: Metadata
@@ -28,7 +28,7 @@ export type PrivateTreeInfo = {
   skeleton: PrivateSkeleton
 }
 
-export type PrivateSkeleton = { [name: string]: PrivateSkeletonInfo}
+export type PrivateSkeleton = { [name: string]: PrivateSkeletonInfo | SoftLink }
 
 export type PrivateSkeletonInfo = {
   cid: CID

--- a/src/fs/protocol/private/types/check.ts
+++ b/src/fs/protocol/private/types/check.ts
@@ -3,7 +3,7 @@ import * as check  from "../../../types/check.js"
 import { PrivateFileInfo, PrivateTreeInfo, PrivateLink, PrivateLinks, DecryptedNode, PrivateSkeletonInfo, PrivateSkeleton } from "../types.js"
 
 export const isDecryptedNode = (obj: any): obj is DecryptedNode => {
-  return isPrivateTreeInfo(obj) || isPrivateFileInfo(obj)
+  return isPrivateTreeInfo(obj) || isPrivateFileInfo(obj) || check.isSoftLink(obj)
 }
 
 export const isPrivateFileInfo = (obj: any): obj is PrivateFileInfo => {
@@ -31,12 +31,12 @@ export const isPrivateLink = (obj: any): obj is PrivateLink => {
 
 export const isPrivateLinks = (obj: any): obj is PrivateLinks => {
   return isObject(obj)
-    && Object.values(obj).every(isPrivateLink)
+    && Object.values(obj).every(a => isPrivateLink(a) || check.isSoftLink(a))
 }
 
 export const isPrivateSkeleton = (obj: any): obj is PrivateSkeleton => {
   return isObject(obj)
-    && Object.values(obj).every(isPrivateSkeletonInfo)
+    && Object.values(obj).every(a => isPrivateSkeletonInfo(a) || check.isSoftLink(a))
 }
 
 export const isPrivateSkeletonInfo = (obj: any): obj is PrivateSkeletonInfo => {

--- a/src/fs/protocol/public/index.ts
+++ b/src/fs/protocol/public/index.ts
@@ -1,5 +1,5 @@
 /** @internal */
-import { Link, Links } from "../../types.js"
+import { Links, HardLink, HardLinks, SimpleLinks } from "../../types.js"
 import { TreeInfo, FileInfo, Skeleton, PutDetails } from "./types.js"
 import { Metadata } from "../../metadata.js"
 import { isString } from "../../../common/type-checks.js"
@@ -63,13 +63,13 @@ export const putFile = async (
   }
 }
 
-export const putAndMakeLink = async (name: string, val: FileContent): Promise<Link> => {
+export const putAndMakeLink = async (name: string, val: FileContent): Promise<HardLink> => {
   const { cid, size } = await ipfs.encoded.add(val, null)
   return link.make(name, cid, true, size)
 }
 
 export const get = async (cid: CID): Promise<TreeInfo | FileInfo> => {
-  const links = await basic.getLinks(cid)
+  const links = await basic.getSimpleLinks(cid)
   const metadata = await getAndCheckValue(links, "metadata", check.isMetadata)
   const skeleton = metadata.isFile
     ? undefined
@@ -83,11 +83,11 @@ export const get = async (cid: CID): Promise<TreeInfo | FileInfo> => {
 }
 
 export const getValue = async (
-  linksOrCID: Links | CID,
+  linksOrCID: SimpleLinks | CID,
   name: string,
 ): Promise<unknown> => {
   if (isString(linksOrCID)) {
-    const links = await basic.getLinks(linksOrCID)
+    const links = await basic.getSimpleLinks(linksOrCID)
     return getValueFromLinks(links, name)
   }
 
@@ -95,7 +95,7 @@ export const getValue = async (
 }
 
 export const getValueFromLinks = async (
-  links: Links,
+  links: SimpleLinks,
   name: string,
 ): Promise<unknown> => {
   const linkCID = links[name]?.cid
@@ -104,7 +104,7 @@ export const getValueFromLinks = async (
   return ipfs.encoded.catAndDecode(linkCID, null)
 }
 export const getAndCheckValue = async <T>(
-  linksOrCid: Links | CID,
+  linksOrCid: SimpleLinks | CID,
   name: string,
   checkFn: (val: any) => val is T,
   canBeNull = false

--- a/src/fs/protocol/public/skeleton.ts
+++ b/src/fs/protocol/public/skeleton.ts
@@ -1,18 +1,20 @@
 import { Skeleton, SkeletonInfo } from "./types.js"
-import { NonEmptyPath } from "../../types.js"
+import { NonEmptyPath, SoftLink } from "../../types.js"
+import { isSoftLink } from "../../types/check.js"
 
 
-export const getPath = (skeleton: Skeleton, path: NonEmptyPath): SkeletonInfo | null => {
+export const getPath = (skeleton: Skeleton, path: NonEmptyPath): SkeletonInfo | SoftLink | null => {
   const head = path[0]
   const child = skeleton[head] || null
   const nextPath = nextNonEmpty(path)
-  if(child === null || nextPath === null) {
+  if (child === null || nextPath === null || isSoftLink(child)) {
     return child
-  }else {
+  } else if (child.subSkeleton) {
     return getPath(child.subSkeleton, nextPath)
+  } else {
+    return null
   }
 }
-
 
 function nextNonEmpty(parts: NonEmptyPath): NonEmptyPath | null {
   const next = parts.slice(1)

--- a/src/fs/protocol/public/types.ts
+++ b/src/fs/protocol/public/types.ts
@@ -1,5 +1,7 @@
 import { Metadata } from "../../metadata.js"
 import { AddResult, CID } from "../../../ipfs/index.js"
+import { SoftLink } from "../../types.js"
+
 
 export type PutDetails = AddResult & {
   userland: CID
@@ -16,7 +18,7 @@ export type SkeletonInfo = {
   isFile: boolean
 }
 
-export type Skeleton = { [name: string]: SkeletonInfo }
+export type Skeleton = { [name: string]: SkeletonInfo | SoftLink }
 
 export type TreeHeader = {
   metadata: Metadata

--- a/src/fs/root/tree.ts
+++ b/src/fs/root/tree.ts
@@ -2,7 +2,7 @@ import * as uint8arrays from "uint8arrays"
 
 import { AddResult, CID } from "../../ipfs/index.js"
 import { BareNameFilter } from "../protocol/private/namefilter.js"
-import { Links, Puttable, SimpleLink } from "../types.js"
+import { Puttable, SimpleLink, SimpleLinks } from "../types.js"
 import { Branch, DistinctivePath } from "../../path.js"
 import { Maybe } from "../../common/index.js"
 import { Permissions } from "../../ucan/permissions.js"
@@ -29,7 +29,7 @@ type PrivateNode = PrivateTree | PrivateFile
 
 export default class RootTree implements Puttable {
 
-  links: Links
+  links: SimpleLinks
   mmpt: MMPT
   privateLog: Array<SimpleLink>
 
@@ -38,7 +38,7 @@ export default class RootTree implements Puttable {
   privateNodes: Record<string, PrivateNode>
 
   constructor({ links, mmpt, privateLog, publicTree, prettyTree, privateNodes }: {
-    links: Links
+    links: SimpleLinks
     mmpt: MMPT
     privateLog: Array<SimpleLink>
 
@@ -101,8 +101,7 @@ export default class RootTree implements Puttable {
   static async fromCID(
     { cid, permissions }: { cid: CID; permissions?: Permissions }
   ): Promise<RootTree> {
-    const links = await protocol.basic.getLinks(cid)
-
+    const links = await protocol.basic.getSimpleLinks(cid)
     const keys = permissions ? await permissionKeys(permissions) : []
 
     // Load public parts

--- a/src/fs/v1/PrivateFile.ts
+++ b/src/fs/v1/PrivateFile.ts
@@ -70,7 +70,7 @@ export class PrivateFile extends BaseFile {
   }
 
   static async fromLatestName(mmpt: MMPT, name: PrivateName, key: string): Promise<PrivateFile> {
-    const info = await protocol.priv.getByLatestName(mmpt, name, key)
+    const info = await protocol.priv.getLatestByName(mmpt, name, key)
     return PrivateFile.fromInfo(mmpt, key, info)
   }
 

--- a/src/path.ts
+++ b/src/path.ts
@@ -188,6 +188,15 @@ export function removeBranch(path: DistinctivePath): DistinctivePath {
 }
 
 /**
+ * Get the last part of the path.
+ */
+export function terminus(path: DistinctivePath): Maybe<string> {
+  const u = unwrap(path)
+  if (u.length < 1) return null
+  return u[u.length - 1]
+}
+
+/**
  * Unwrap a `DistinctivePath`.
  */
 export function unwrap(path: DistinctivePath): Path {

--- a/tests/fs/api.private.node.test.ts
+++ b/tests/fs/api.private.node.test.ts
@@ -2,6 +2,7 @@ import expect from "expect"
 import * as fc from "fast-check"
 
 import "../../src/setup/node.js"
+import * as check from "../../src/fs/types/check.js"
 import * as path from "../../src/path.js"
 
 import { pathSegment, pathSegmentPair } from "../helpers/paths.js"
@@ -18,6 +19,7 @@ describe("the private filesystem api", function () {
   after(async () => {
     fc.resetConfigureGlobal()
   })
+
 
   it("writes files", async () => {
     const fs = await emptyFilesystem()
@@ -202,6 +204,62 @@ describe("the private filesystem api", function () {
           const toExists = await fs.exists(toPath)
 
           expect(toExists && !fromExists).toEqual(true)
+        })
+    )
+  })
+
+  it("makes soft links to directories", async () => {
+    const fs = await emptyFilesystem()
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({ pathSegmentPair: pathSegmentPair(), fileContent: fileContent() }),
+        async ({ pathSegmentPair, fileContent }) => {
+          const atPath = path.directory("private", pathSegmentPair.first)
+          const destinationPath = path.directory("private", pathSegmentPair.second)
+          const name = path.terminus(destinationPath) || "Symlink"
+
+          await fs.mkdir(destinationPath)
+          await fs.symlink({
+            at: atPath,
+            referringTo: destinationPath,
+            name,
+            username: "test"
+          })
+
+          const at = await fs.get(atPath)
+          const symlink = check.isFile(at) || at === null ? null : at.getLinks()[name]
+
+          expect(!!symlink).toEqual(true)
+          expect(check.isSoftLink(symlink)).toEqual(true)
+        })
+    )
+  })
+
+  it("makes soft links to files", async () => {
+    const fs = await emptyFilesystem()
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({ pathSegmentPair: pathSegmentPair(), fileContent: fileContent() }),
+        async ({ pathSegmentPair, fileContent }) => {
+          const atPath = path.directory("private", pathSegmentPair.first)
+          const destinationPath = path.file("private", pathSegmentPair.second)
+          const name = path.terminus(destinationPath) || "Symlink"
+
+          await fs.write(destinationPath, "")
+          await fs.symlink({
+            at: atPath,
+            referringTo: destinationPath,
+            name,
+            username: "test"
+          })
+
+          const at = await fs.get(atPath)
+          const symlink = check.isFile(at) || at === null ? null : at.getLinks()[name]
+
+          expect(!!symlink).toEqual(true)
+          expect(check.isSoftLink(symlink)).toEqual(true)
         })
     )
   })

--- a/tests/fs/integration.node.test.ts
+++ b/tests/fs/integration.node.test.ts
@@ -9,6 +9,7 @@ import * as path from "../../src/path.js"
 
 import { ipfsFromContext } from "../mocha-hook.js"
 import { loadFilesystem } from "../helpers/filesystem.js"
+import { isSoftLink } from "../../src/fs/types/check.js"
 
 
 describe("the filesystem", () => {
@@ -30,6 +31,7 @@ describe("the filesystem", () => {
 async function listFiles(fs: FileSystem, searchPath: path.DirectoryPath): Promise<File[]> {
   let files: File[] = []
   for (const [subName, sub] of Object.entries(await fs.ls(searchPath))) {
+    if (isSoftLink(sub)) continue
     if (sub.isFile) {
       const file = await fs.get(path.combine(searchPath, path.file(subName))) as File
       files.push(file)


### PR DESCRIPTION
# Adds soft/symbolic links

Symbolic links are in the following format:
```javascript
// Public soft link
{
  ipns: "icidasset.files.fission.name/public/path/example.file",
  name: "example.file"
}

// Private soft link
{
  ipns: "icidasset.files.fission.name",
  name: "example.file",
  key: aes_key,
  privateName: "..."
}
```
The `name` is name of your symbolic link, and the other properties involve the original file or directory. When a soft link is resolved, webnative will lookup the DNSLink, load the part we need of the other person's filesystem and then get the file or directory (read only).

This PR implements the following functions:
```javascript
// Top level soft link creation
fs.symlink({ at: DirectoryPath, referringTo: DistinctivePath, name: string, username?: string }): Promise<this>

// Lower level soft link creation
publicOrPrivateTree.insertSoftLink({ name: string, path: DistinctivePath, username: string }): this
publicOrPrivateTree.resolveSoftLink(link: SoftLink): Promise<Tree | File | null>

// Assign a new child somewhere down the tree
tree.updateChild(child: Tree | File, path: Path)
```

and changes the type of `Link` to `SoftLink | HardLink`.

Soft links are automatically resolved when using `fs.get()` and `tree.get()` (or `tree.getDirectChild()`). For the time being it always does the DNS lookup, plus loading the remote filesystem. We could do some light optimisation here, like checking if it's the current user, and if so, use the currently loaded filesystem itself. Soft links are not resolved automatically when using `fs.ls()`.

Other indirect changes:
- Files and trees have a `readOnly` attribute, because soft links are read only.
- Files and trees that are read-only cannot be mutated.
- Removes `mtime` from hard links (that info can be found in the metadata anyway)
- Added `path.terminus()` to get the last part of a path

Closes #75