### PR TITLE
Bump one-webcrypto to 1.0.3 and keystore-idb to 0.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.29.2
+
+- Make webnative work across more environments and bundlers (upgrade one-webcrypto to 1.0.3)
+
 ### v0.29.1
 
 - Check the wnfs version field when initialising a filesystem and alert users about outdated filesystems or outdated apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",
@@ -99,10 +99,10 @@
     "ipfs-message-port-client": "^0.9.2-rc.2",
     "ipfs-message-port-protocol": "^0.10.2-rc.2",
     "ipld-dag-pb": "^0.22.2",
-    "keystore-idb": "^0.15.3",
+    "keystore-idb": "^0.15.4",
     "localforage": "^1.9.0",
     "multiformats": "^9.4.8",
-    "one-webcrypto": "^1.0.1",
+    "one-webcrypto": "^1.0.3",
     "throttle-debounce": "^3.0.1",
     "tweetnacl": "^0.14.5",
     "uint8arrays": "^2.1.7"

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.29.1"
+export const VERSION = "0.29.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,6 +337,8 @@ interface AuthLobbyClassifiedInfo {
 async function importClassifiedInfo(
   classifiedInfo: AuthLobbyClassifiedInfo
 ): Promise<void> {
+
+  console.log(classifiedInfo)
   // Extract session key and its iv
   const rawSessionKey = await crypto.keystore.decrypt(classifiedInfo.sessionKey)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,13 +2863,13 @@ keypair@^1.0.1:
   resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.4.tgz#a749a45f388593f3950f18b3757d32a93bd8ce83"
   integrity sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg==
 
-keystore-idb@^0.15.3:
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.15.3.tgz#827b37e0d011fef5591afa3e6bf97dcc759f36ca"
-  integrity sha512-yYvxK/ecgnrqUO/YQJPJxHW7lvTxlYWsgp9gC7N0LLejjYLy69yGrmT8Iw79VgymicU8cijmydgyUnTWJFHasA==
+keystore-idb@^0.15.4:
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.15.4.tgz#ba2387a6a6284421f023c0719d099eb9d2c9cfa8"
+  integrity sha512-3HfkebZQzo7iFA301aXTizupfwlWk350uwCjdUY2p6v9jVP0B1frySTgesInqjHaj66mpridvg8WNF43JErEQg==
   dependencies:
     localforage "^1.10.0"
-    one-webcrypto "^1.0.1"
+    one-webcrypto "^1.0.3"
     uint8arrays "^3.0.0"
 
 level-codec@^10.0.0:
@@ -3731,10 +3731,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-one-webcrypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/one-webcrypto/-/one-webcrypto-1.0.1.tgz#023dcf8983276dc568a0ecfc71aa71ad045190b8"
-  integrity sha512-yFtrnpAgreBUDgEM/iTMGXwCnyyo/zwTOly/Pqx8T8TFd79QUv0OI+WkVMvCVgBg5Eja7Uo12x2M7v7RJPba8A==
+one-webcrypto@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/one-webcrypto/-/one-webcrypto-1.0.3.tgz#f951243cde29b79b6745ad14966fc598a609997c"
+  integrity sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==
 
 onetime@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Allows webnative to be used in more environments.

Main action is a version bump of one-webcrypto to 1.0.3 and keystore-idb to 0.15.4 (which again is only due to a version bump of one-webcrypto).

Discussed in #318 