### PR TITLE
Remove debug console.log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -338,7 +338,6 @@ async function importClassifiedInfo(
   classifiedInfo: AuthLobbyClassifiedInfo
 ): Promise<void> {
 
-  console.log(classifiedInfo)
   // Extract session key and its iv
   const rawSessionKey = await crypto.keystore.decrypt(classifiedInfo.sessionKey)
 


### PR DESCRIPTION
Just a console.log that slipped through.

It prints the variable "classifiedInfo", but that's not dangerous. The contents of that variable are encrypted with a non-extractable key.

Still, not necessary to have that printing.