### PR TITLE
Fix version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.30.0-alpha4",
+  "version": "0.30.0-alpha5",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.30.0-alpha5",
+  "version": "0.30.0-alpha6",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.30.0-alpha5"
+export const VERSION = "0.30.0-alpha6"

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.30.0-alpha4"
+export const VERSION = "0.30.0-alpha5"

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -80,7 +80,7 @@ export async function loadFileSystem(
   const p = permissions || undefined
 
   if (cid != null) {
-    await checkVersion(cid)
+    await checkFileSystemVersion(cid)
     fs = await FileSystem.fromCID(cid, { permissions: p })
     if (fs != null) return fs
   }
@@ -95,7 +95,7 @@ export async function loadFileSystem(
 }
 
 
-export async function checkVersion(filesystemCID: CID): Promise<void> {
+export async function checkFileSystemVersion(filesystemCID: CID): Promise<void> {
   const links = await protocol.basic.getSimpleLinks(filesystemCID)
   // if there's no version link, we assume it's from a 1.0.0-compatible version
   // (from before ~ November 2020)

--- a/src/fs/versions.ts
+++ b/src/fs/versions.ts
@@ -36,7 +36,9 @@ export const toString = (version: SemVer): string => {
 }
 
 export const isSmallerThan = (a: SemVer, b: SemVer): boolean => {
-  return a.major < b.major || a.minor < b.major || a.patch < b.patch
+  if (a.major != b.major) return a.major < b.major
+  if (a.minor != b.minor) return a.minor < b.minor
+  return a.patch < b.patch
 }
 
 

--- a/src/setup/internal.ts
+++ b/src/setup/internal.ts
@@ -45,8 +45,8 @@ export const setup: Setup = {
 
   userMessages: {
     versionMismatch: {
-      newer: async () => alertIfPossible(`Sorry, we can't sync your filesystem with this app. This app only understands older versions of filesystems. Please try to hard refresh this site or let this app's developer know. Feel free to contact Fission support: support@fission.codes`),
-      older: async () => alertIfPossible(`Sorry, we can't sync your filesystem with this app. Your filesystem version is out-dated and it needs to be migrated. Use the migration app or talk to Fission support: support@fission.codes`),
+      newer: async () => alertIfPossible(`Sorry, we can't sync your filesystem with this app. This app only understands older versions of filesystems.\n\nPlease try to hard refresh this site or let this app's developer know.\n\nFeel free to contact Fission support: support@fission.codes`),
+      older: async () => alertIfPossible(`Sorry, we can't sync your filesystem with this app. Your filesystem version is out-dated and it needs to be migrated.\n\nRun a migration (https://guide.fission.codes/accounts/account-signup/account-migration) or talk to Fission support: support@fission.codes`),
     }
   },
 

--- a/tests/fs/versioning.node.test.ts
+++ b/tests/fs/versioning.node.test.ts
@@ -2,7 +2,7 @@ import expect from "expect"
 
 import * as path from "../../src/path.js"
 import * as versions from "../../src/fs/versions.js"
-import { checkVersion } from "../../src/filesystem.js"
+import { checkFileSystemVersion } from "../../src/filesystem.js"
 
 import { emptyFilesystem } from "../helpers/filesystem.js"
 
@@ -15,7 +15,7 @@ describe("the filesystem versioning system", () => {
         await fs.root.setVersion(versions.encode(versions.latest.major + 1, 0, 0))
         const changedCID = await fs.root.put()
 
-        await expect(checkVersion(changedCID)).rejects.toBeDefined()
+        await expect(checkFileSystemVersion(changedCID)).rejects.toBeDefined()
     })
 
     it("throws an error if the version is too low", async function() {
@@ -24,7 +24,7 @@ describe("the filesystem versioning system", () => {
         await fs.root.setVersion(versions.encode(versions.latest.major - 1, 0, 0))
         const changedCID = await fs.root.put()
 
-        await expect(checkVersion(changedCID)).rejects.toBeDefined()
+        await expect(checkFileSystemVersion(changedCID)).rejects.toBeDefined()
     })
 
 })


### PR DESCRIPTION
The `isSmallerThan` function was incorrect. This should fix it.

```js
$ node --experimental-repl-await
Welcome to Node.js v16.9.1.
Type ".help" for more information.
> versions = await import("./lib/fs/versions.js")
> versions.isSmallerThan(versions.fromString("1.0.0"), versions.fromString("1.0.0"))
false
> versions.isSmallerThan(versions.fromString("1.0.0"), versions.fromString("2.0.0"))
true
> versions.isSmallerThan(versions.fromString("1.0.0"), versions.fromString("1.1.0"))
true
> versions.isSmallerThan(versions.fromString("1.0.0"), versions.fromString("1.0.1"))
true
> versions.isSmallerThan(versions.fromString("1.0.1"), versions.fromString("1.0.1"))
false
> versions.isSmallerThan(versions.fromString("0.0.1"), versions.fromString("1.0.1"))
true
> versions.isSmallerThan(versions.fromString("0.4.1"), versions.fromString("1.0.1"))
true
> versions.isSmallerThan(versions.fromString("1.4.1"), versions.fromString("1.0.1"))
false
```

Also, this PR renames `checkVersion` into `checkFileSystemVersion`, because that's exposed to the webnative global scope just like `loadFileSystem`, so I made the naming match that.