### PR TITLE
App owned logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   Apps need to update to this webnative version to load migrated/new filesystems.
 - Adds ability to share private files.
 - Adds soft/symbolic links.
+- Add dependency injection for initialise and registering accounts
 
 
 

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,18 @@
+import { impl } from "../setup/dependencies.js"
+import { InitOptions, State } from "../index.js"
+
+export const init = (options: InitOptions): Promise<State | null> => {
+  return impl.auth.init(options)
+}
+
+export const register = (options: { username: string; email: string }): Promise<{success: boolean}> => {
+  return impl.auth.register(options)
+}
+
+export const isUsernameValid = (username: string): Promise<boolean> => {
+  return impl.auth.isUsernameValid(username)
+}
+
+export const isUsernameAvailable = (username: string): Promise<boolean> => {
+  return impl.auth.isUsernameAvailable(username)
+}

--- a/src/auth/lobby.ts
+++ b/src/auth/lobby.ts
@@ -1,0 +1,235 @@
+import * as identifiers from "../common/identifiers.js"
+import * as common from "../common/index.js"
+import { USERNAME_STORAGE_KEY } from "../common/index.js"
+import * as crypto from "../crypto/index.js"
+import * as did from "../did/index.js"
+import { loadFileSystem } from "../filesystem.js"
+import FileSystem from "../fs/index.js"
+import { InitOptions, scenarioAuthCancelled, scenarioAuthSucceeded, scenarioNotAuthorised, State, validateSecrets } from "../index.js"
+import * as ipfs from "../ipfs/index.js"
+import * as user from "../lobby/username.js"
+import * as pathing from "../path.js"
+import { setup } from "../setup/internal.js"
+import * as storage from "../storage/index.js"
+import * as ucan from "../ucan/internal.js"
+
+export const init = async (options: InitOptions): Promise<State | null> => {
+  const permissions = options.permissions || null
+  const { autoRemoveUrlParams = true, rootKey } = options
+
+  // TODO: should be shared? 
+  const maybeLoadFs = async (username: string): Promise<undefined | FileSystem> => {
+    return options.loadFileSystem === false
+      ? undefined
+      : await loadFileSystem(permissions, username, rootKey)
+  }
+
+  // URL things
+  const url = new URL(window.location.href)
+  const authorised = url.searchParams.get("authorised")
+  const cancellation = url.searchParams.get("cancelled")
+
+  // Determine scenario
+  if (authorised) {
+    const newUser = url.searchParams.get("newUser") === "t"
+    const username = url.searchParams.get("username") || ""
+
+    await retry(async () => importClassifiedInfo(
+      authorised === "via-postmessage"
+        ? await getClassifiedViaPostMessage()
+        : JSON.parse(await ipfs.cat(authorised)) // in any other case we expect it to be a CID
+    ), { tries: 10, timeout: 10000, timeoutMessage: "Trying to retrieve UCAN(s) and readKey(s) from the auth lobby timed out after 10 seconds." })
+
+    await storage.setItem(USERNAME_STORAGE_KEY, username)
+
+    if (autoRemoveUrlParams) {
+      url.searchParams.delete("authorised")
+      url.searchParams.delete("newUser")
+      url.searchParams.delete("username")
+      history.replaceState(null, document.title, url.toString())
+    }
+
+    if (permissions && await validateSecrets(permissions) === false) {
+      console.warn("Unable to validate filesystem secrets")
+      return scenarioNotAuthorised(permissions)
+    }
+
+    if (permissions && ucan.validatePermissions(permissions, username) === false) {
+      console.warn("Unable to validate UCAN permissions")
+      return scenarioNotAuthorised(permissions)
+    }
+
+    return scenarioAuthSucceeded(
+      permissions,
+      newUser,
+      username,
+      await maybeLoadFs(username)
+    )
+
+  } else if (cancellation) {
+    const c = (() => {
+      switch (cancellation) {
+        case "DENIED": return "User denied authorisation"
+        default: return "Unknown reason"
+      }
+    })()
+
+    return scenarioAuthCancelled(permissions, c)
+  } else {
+    await ucan.store([])
+  }
+
+  return null
+}
+
+export const register = async (options: { username: string; email: string }): Promise<{ success: boolean }> => {
+  return new Promise(resolve => resolve({ success: false }))
+}
+
+export const isUsernameValid = async (username: string): Promise<boolean> => {
+  return user.isUsernameValid(username)
+}
+
+export const isUsernameAvailable = async (username: string): Promise<boolean> => {
+  return user.isUsernameAvailable(username)
+}
+
+// HELPERS
+
+async function retry(action: () => Promise<void>, options: { tries: number; timeout: number; timeoutMessage: string }): Promise<void> {
+  return await Promise.race([
+    (async () => {
+      let tryNum = 1
+      while (tryNum <= options.tries) {
+        try {
+          await action()
+          return
+        } catch (e) {
+          if (tryNum == options.tries) {
+            throw e
+          }
+        }
+        tryNum++
+      }
+    })(),
+    new Promise<void>((resolve, reject) => setTimeout(() => reject(new Error(options.timeoutMessage)), options.timeout))
+  ])
+}
+
+interface AuthLobbyClassifiedInfo {
+  sessionKey: string
+  secrets: string
+  iv: string
+}
+
+function isAuthLobbyClassifiedInfo(obj: unknown): obj is AuthLobbyClassifiedInfo {
+  return common.isObject(obj)
+    && common.isString(obj.sessionKey)
+    && common.isString(obj.secrets)
+    && common.isString(obj.iv)
+}
+
+async function importClassifiedInfo(
+  classifiedInfo: AuthLobbyClassifiedInfo
+): Promise<void> {
+
+  console.log(classifiedInfo)
+  // Extract session key and its iv
+  const rawSessionKey = await crypto.keystore.decrypt(classifiedInfo.sessionKey)
+
+  // Decrypt secrets
+  const secretsStr = await crypto.aes.decryptGCM(classifiedInfo.secrets, rawSessionKey, classifiedInfo.iv)
+  const secrets = JSON.parse(secretsStr)
+
+  const fsSecrets: Record<string, { key: string; bareNameFilter: string }> = secrets.fs
+  const ucans = secrets.ucans
+
+  // Import read keys and bare name filters
+  await Promise.all(
+    Object.entries(fsSecrets).map(async ([posixPath, { bareNameFilter, key }]) => {
+      const path = pathing.fromPosix(posixPath)
+      const readKeyId = await identifiers.readKey({ path })
+      const bareNameFilterId = await identifiers.bareNameFilter({ path })
+
+      await crypto.keystore.importSymmKey(key, readKeyId)
+      await storage.setItem(bareNameFilterId, bareNameFilter)
+    })
+  )
+
+  // Add UCANs to the storage
+  await ucan.store(ucans)
+}
+
+async function getClassifiedViaPostMessage(): Promise<AuthLobbyClassifiedInfo> {
+  const iframe: HTMLIFrameElement = await new Promise(resolve => {
+    const iframe = document.createElement("iframe")
+    iframe.id = "webnative-secret-exchange"
+    iframe.style.width = "0"
+    iframe.style.height = "0"
+    iframe.style.border = "none"
+    iframe.style.display = "none"
+    document.body.appendChild(iframe)
+
+    iframe.onload = () => {
+      resolve(iframe)
+    }
+
+    iframe.src = `${setup.endpoints.lobby}/exchange.html`
+  })
+
+  try {
+
+    const answer: Promise<AuthLobbyClassifiedInfo> = new Promise((resolve, reject) => {
+      let tries = 10
+      window.addEventListener("message", listen)
+
+      function retryOrReject(eventData?: string) {
+        console.warn(`When importing UCANs & readKey(s): Can't parse: ${eventData}. Might be due to extensions.`)
+        if (--tries === 0) {
+          window.removeEventListener("message", listen)
+          reject(new Error("Couldn't parse message from auth lobby after 10 tries. See warnings above."))
+        }
+      }
+
+      function listen(event: MessageEvent<string>) {
+        if (new URL(event.origin).host !== new URL(setup.endpoints.lobby).host) {
+          console.log(`Got a message from ${event.origin} while waiting for login credentials. Ignoring.`)
+          return
+        }
+
+        if (event.data == null) {
+          // Might be an extension sending a message without data
+          return
+        }
+
+        let classifiedInfo: unknown = null
+        try {
+          classifiedInfo = JSON.parse(event.data)
+        } catch {
+          retryOrReject(event.data)
+          return
+        }
+
+        if (!isAuthLobbyClassifiedInfo(classifiedInfo)) {
+          retryOrReject(event.data)
+          return
+        }
+
+        window.removeEventListener("message", listen)
+        resolve(classifiedInfo)
+      }
+    })
+
+    if (iframe.contentWindow == null) throw new Error("Can't import UCANs & readKey(s): No access to its contentWindow")
+    const message = {
+      webnative: "exchange-secrets",
+      didExchange: await did.exchange()
+    }
+    iframe.contentWindow.postMessage(message, iframe.src)
+
+    return await answer
+
+  } finally {
+    document.body.removeChild(iframe)
+  }
+}

--- a/src/auth/local.ts
+++ b/src/auth/local.ts
@@ -1,0 +1,37 @@
+import { State } from "../index.js"
+import { createAccount } from "../lobby/index.js"
+import * as user from "../lobby/username.js"
+import * as storage from "../storage/index.js"
+import { USERNAME_STORAGE_KEY } from "../common/index.js"
+
+export const init = async (): Promise<State | null> => {
+  console.log("initialize local auth")
+  return new Promise((resolve) => resolve(null))
+}
+
+export const register = async (options: { username: string; email: string}): Promise<{success: boolean}> => {
+  const { success } = await createAccount(options)
+
+  if (success) {
+    await storage.setItem(USERNAME_STORAGE_KEY, options.username)
+    return { success: true }
+  }
+  return { success: false }
+}
+
+export const isUsernameValid = async (username: string): Promise<boolean> => {
+  return user.isUsernameValid(username)
+}
+
+export const isUsernameAvailable = async (username: string): Promise<boolean> => {
+  return user.isUsernameAvailable(username)
+}
+
+export const LOCAL_IMPLEMENTATION = {
+  auth: {
+    init,
+    register,
+    isUsernameValid,
+    isUsernameAvailable
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,14 @@
 import localforage from "localforage"
 
+import * as auth from "./auth/index.js"
 import * as common from "./common/index.js"
 import * as identifiers from "./common/identifiers.js"
-import * as ipfs from "./ipfs/index.js"
 import * as pathing from "./path.js"
 import * as crypto from "./crypto/index.js"
-import * as storage from "./storage/index.js"
 import * as ucan from "./ucan/internal.js"
 import * as ucanPermissions from "./ucan/permissions.js"
-import { setup } from "./setup/internal.js"
-import * as did from "./did/index.js"
 
-import { USERNAME_STORAGE_KEY, Maybe } from "./common/index.js"
+import { Maybe } from "./common/index.js"
 import { Permissions } from "./ucan/permissions.js"
 import { loadFileSystem } from "./filesystem.js"
 
@@ -95,7 +92,14 @@ export enum InitialisationError {
 
 
 // INTIALISE
+export type InitOptions = {
+  permissions?: Permissions
 
+  // Options
+  autoRemoveUrlParams?: boolean
+  loadFileSystem?: boolean
+  rootKey?: string
+}
 
 /**
  * Check if we're authenticated, process any lobby query-parameters present in the URL,
@@ -104,20 +108,11 @@ export enum InitialisationError {
  * See `loadFileSystem` if you want to load the user's file system yourself.
  * NOTE: Only works on the main/ui thread, as it uses `window.location`.
  */
-export async function initialise(
-  options: {
-    permissions?: Permissions
-
-    // Options
-    autoRemoveUrlParams?: boolean
-    loadFileSystem?: boolean
-    rootKey?: string
-  }
-): Promise<State> {
+export async function initialise(options: InitOptions): Promise<State> {
   options = options || {}
 
   const permissions = options.permissions || null
-  const { autoRemoveUrlParams = true, rootKey } = options
+  const { rootKey } = options
 
   const maybeLoadFs = async (username: string): Promise<undefined | FileSystem> => {
     return options.loadFileSystem === false
@@ -129,62 +124,10 @@ export async function initialise(
   if (globalThis.isSecureContext === false) throw InitialisationError.InsecureContext
   if (await isSupported() === false) throw InitialisationError.UnsupportedBrowser
 
-  // URL things
-  const url = new URL(window.location.href)
-  const authorised = url.searchParams.get("authorised")
-  const cancellation = url.searchParams.get("cancelled")
-
-  // Determine scenario
-  if (authorised) {
-    const newUser = url.searchParams.get("newUser") === "t"
-    const username = url.searchParams.get("username") || ""
-
-    await retry(async () => importClassifiedInfo(
-      authorised === "via-postmessage"
-        ? await getClassifiedViaPostMessage()
-        : JSON.parse(await ipfs.cat(authorised)) // in any other case we expect it to be a CID
-    ), { tries: 10, timeout: 10000, timeoutMessage: "Trying to retrieve UCAN(s) and readKey(s) from the auth lobby timed out after 10 seconds." })
-
-    await storage.setItem(USERNAME_STORAGE_KEY, username)
-
-    if (autoRemoveUrlParams) {
-      url.searchParams.delete("authorised")
-      url.searchParams.delete("newUser")
-      url.searchParams.delete("username")
-      history.replaceState(null, document.title, url.toString())
-    }
-
-    if (permissions && await validateSecrets(permissions) === false) {
-      console.warn("Unable to validate filesystem secrets")
-      return scenarioNotAuthorised(permissions)
-    }
-
-    if (permissions && ucan.validatePermissions(permissions, username) === false) {
-      console.warn("Unable to validate UCAN permissions")
-      return scenarioNotAuthorised(permissions)
-    }
-
-    return scenarioAuthSucceeded(
-      permissions,
-      newUser,
-      username,
-      await maybeLoadFs(username)
-    )
-
-  } else if (cancellation) {
-    const c = (() => {
-      switch (cancellation) {
-        case "DENIED": return "User denied authorisation"
-        default: return "Unknown reason"
-      }
-    })()
-
-    return scenarioAuthCancelled(permissions, c)
-
-  } else {
-    // trigger build for internal ucan dictionary
-    await ucan.store([])
-
+  const state = await auth.init(options)
+  // Allow auth implementation to return a State directly
+  if (state) {
+    return state
   }
 
   const authedUsername = await common.authenticatedUsername()
@@ -263,7 +206,7 @@ export * as cbor from "cborg"
 // ㊙️  ⚛  SCENARIOS
 
 
-function scenarioAuthSucceeded(
+export function scenarioAuthSucceeded(
   permissions: Maybe<Permissions>,
   newUser: boolean,
   username: string,
@@ -281,7 +224,7 @@ function scenarioAuthSucceeded(
   }
 }
 
-function scenarioAuthCancelled(
+export function scenarioAuthCancelled(
   permissions: Maybe<Permissions>,
   cancellationReason: string
 ): AuthCancelled {
@@ -295,7 +238,7 @@ function scenarioAuthCancelled(
   }
 }
 
-function scenarioContinuation(
+export function scenarioContinuation(
   permissions: Maybe<Permissions>,
   username: string,
   fs: FileSystem | undefined
@@ -312,7 +255,7 @@ function scenarioContinuation(
   }
 }
 
-function scenarioNotAuthorised(
+export function scenarioNotAuthorised(
   permissions: Maybe<Permissions>
 ): NotAuthorised {
   return {
@@ -324,120 +267,7 @@ function scenarioNotAuthorised(
 }
 
 
-
-// ㊙️
-
-interface AuthLobbyClassifiedInfo {
-  sessionKey: string
-  secrets: string
-  iv: string
-}
-
-
-async function importClassifiedInfo(
-  classifiedInfo: AuthLobbyClassifiedInfo
-): Promise<void> {
-  // Extract session key and its iv
-  const rawSessionKey = await crypto.keystore.decrypt(classifiedInfo.sessionKey)
-
-  // Decrypt secrets
-  const secretsStr = await crypto.aes.decryptGCM(classifiedInfo.secrets, rawSessionKey, classifiedInfo.iv)
-  const secrets = JSON.parse(secretsStr)
-
-  const fsSecrets: Record<string, { key: string; bareNameFilter: string }> = secrets.fs
-  const ucans = secrets.ucans
-
-  // Import read keys and bare name filters
-  await Promise.all(
-    Object.entries(fsSecrets).map(async ([posixPath, { bareNameFilter, key }]) => {
-      const path = pathing.fromPosix(posixPath)
-      const readKeyId = await identifiers.readKey({ path })
-      const bareNameFilterId = await identifiers.bareNameFilter({ path })
-
-      await crypto.keystore.importSymmKey(key, readKeyId)
-      await storage.setItem(bareNameFilterId, bareNameFilter)
-    })
-  )
-
-  // Add UCANs to the storage
-  await ucan.store(ucans)
-}
-
-async function getClassifiedViaPostMessage(): Promise<AuthLobbyClassifiedInfo> {
-  const iframe: HTMLIFrameElement = await new Promise(resolve => {
-    const iframe = document.createElement("iframe")
-    iframe.id = "webnative-secret-exchange"
-    iframe.style.width = "0"
-    iframe.style.height = "0"
-    iframe.style.border = "none"
-    iframe.style.display = "none"
-    document.body.appendChild(iframe)
-
-    iframe.onload = () => {
-      resolve(iframe)
-    }
-
-    iframe.src = `${setup.endpoints.lobby}/exchange.html`
-  })
-
-  try {
-
-    const answer: Promise<AuthLobbyClassifiedInfo> = new Promise((resolve, reject) => {
-      let tries = 10
-      window.addEventListener("message", listen)
-
-      function retryOrReject(eventData?: string) {
-        console.warn(`When importing UCANs & readKey(s): Can't parse: ${eventData}. Might be due to extensions.`)
-        if (--tries === 0) {
-          window.removeEventListener("message", listen)
-          reject(new Error("Couldn't parse message from auth lobby after 10 tries. See warnings above."))
-        }
-      }
-
-      function listen(event: MessageEvent<string>) {
-        if (new URL(event.origin).host !== new URL(setup.endpoints.lobby).host) {
-          console.log(`Got a message from ${event.origin} while waiting for login credentials. Ignoring.`)
-          return
-        }
-
-        if (event.data == null) {
-          // Might be an extension sending a message without data
-          return
-        }
-
-        let classifiedInfo: unknown = null
-        try {
-          classifiedInfo = JSON.parse(event.data)
-        } catch {
-          retryOrReject(event.data)
-          return
-        }
-
-        if (!isAuthLobbyClassifiedInfo(classifiedInfo)) {
-          retryOrReject(event.data)
-          return
-        }
-
-        window.removeEventListener("message", listen)
-        resolve(classifiedInfo)
-      }
-    })
-
-    if (iframe.contentWindow == null) throw new Error("Can't import UCANs & readKey(s): No access to its contentWindow")
-    const message = {
-      webnative: "exchange-secrets",
-      didExchange: await did.exchange()
-    }
-    iframe.contentWindow.postMessage(message, iframe.src)
-
-    return await answer
-
-  } finally {
-    document.body.removeChild(iframe)
-  }
-}
-
-async function validateSecrets(permissions: Permissions): Promise<boolean> {
+export async function validateSecrets(permissions: Permissions): Promise<boolean> {
   return ucanPermissions.paths(permissions).reduce(
     (acc, path) => acc.then(async bool => {
       if (bool === false) return bool
@@ -448,38 +278,4 @@ async function validateSecrets(permissions: Permissions): Promise<boolean> {
     }),
     Promise.resolve(true)
   )
-}
-
-async function retry(action: () => Promise<void>, options: { tries: number; timeout: number; timeoutMessage: string }): Promise<void> {
-  return await Promise.race([
-    (async () => {
-      let tryNum = 1
-      while (tryNum <= options.tries) {
-        try {
-          await action()
-          return
-        } catch (e) {
-          if (tryNum == options.tries) {
-            throw e
-          }
-        }
-        tryNum++
-      }
-    })(),
-    new Promise<void>((resolve, reject) => setTimeout(() => reject(new Error(options.timeoutMessage)), options.timeout))
-  ])
-}
-
-
-interface AuthLobbyClassifiedInfo {
-  sessionKey: string
-  secrets: string
-  iv: string
-}
-
-function isAuthLobbyClassifiedInfo(obj: unknown): obj is AuthLobbyClassifiedInfo {
-  return common.isObject(obj)
-    && common.isString(obj.sessionKey)
-    && common.isString(obj.secrets)
-    && common.isString(obj.iv)
 }

--- a/src/setup/dependencies.ts
+++ b/src/setup/dependencies.ts
@@ -1,5 +1,7 @@
 import * as browserCrypto from "../crypto/browser.js"
 import * as browserStorage from "../storage/browser.js"
+import * as authLobby from "../auth/lobby.js"
+import { InitOptions, State } from "../index.js"
 
 
 export const DEFAULT_IMPLEMENTATION: Dependencies = {
@@ -25,7 +27,13 @@ export const DEFAULT_IMPLEMENTATION: Dependencies = {
     setItem: browserStorage.setItem,
     removeItem: browserStorage.removeItem,
     clear: browserStorage.clear,
-  }
+  },
+  auth: {
+    init: authLobby.init,
+    register: authLobby.register,
+    isUsernameValid: authLobby.isUsernameValid,
+    isUsernameAvailable: authLobby.isUsernameAvailable,
+  },
 }
 
 export let impl: Dependencies = DEFAULT_IMPLEMENTATION
@@ -36,6 +44,7 @@ export const setDependencies = (fns: Partial<Dependencies>): Dependencies => {
     ed25519: merge(impl.ed25519, fns.ed25519),
     keystore: merge(impl.keystore, fns.keystore),
     storage: merge(impl.storage, fns.storage),
+    auth: merge(impl.auth, fns.auth),
   }
   return impl
 }
@@ -61,7 +70,7 @@ export interface Dependencies {
     sign: (message: string, charSize: number) => Promise<string>
     importSymmKey: (key: string, name: string) => Promise<void>
     exportSymmKey: (name: string) => Promise<string>
-    keyExists: (keyName:string) => Promise<boolean>
+    keyExists: (keyName: string) => Promise<boolean>
     getAlg: () => Promise<string>
     clear: () => Promise<void>
   }
@@ -70,5 +79,11 @@ export interface Dependencies {
     setItem: <T>(key: string, val: T) => Promise<T>
     removeItem: (key: string) => Promise<void>
     clear: () => Promise<void>
+  }
+  auth: {
+    init: (options: InitOptions) => Promise<State | null>
+    register: (options: { email: string; username: string }) => Promise<{ success: boolean }>
+    isUsernameValid: (username: string) => Promise<boolean>
+    isUsernameAvailable: (username: string) => Promise<boolean>
   }
 }


### PR DESCRIPTION
This PR introduces dependency injection for initialization and account registration (along with the various username validation features). This allows apps to override these and potentially use alternative authentication backends / mechanisms.

It also introduces a "local" version that allows an app to init/register accounts in a self-contained manner like this:

```js
import { LOCAL_IMPLEMENTATION } from "webnative/auth/local";
setDependencies(LOCAL_IMPLEMENTATION);
wn.initialise({ loadFileSystem: false })
  .then((result) => {
    const { authenticated, username } = result;
    if (authenticated) {
      console.log(`Logged in as: ${username}`)
    }
  })
  .catch((e) => console.error(e));
```

Closes #316 
Closes #302 