### PR TITLE
Don't `put` multiple times and add MMPT warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.30.0-alpha7",
+  "version": "0.30.0-alpha8",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.30.0-alpha7"
+export const VERSION = "0.30.0-alpha8"

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -207,8 +207,7 @@ abstract class BaseTree implements Tree, UnixTree {
     }, Promise.resolve(this))
 
     await chain.reverse().reduce(async (promise, [name, parent]) => {
-      const c = await promise
-      await parent.updateDirectChild(c, name, () => parent.put())
+      await parent.updateDirectChild(await promise, name, null)
       return parent
     }, Promise.resolve(child))
 

--- a/src/fs/base/tree.ts
+++ b/src/fs/base/tree.ts
@@ -185,6 +185,10 @@ abstract class BaseTree implements Tree, UnixTree {
       : this.createChildTree(name, onUpdate)
   }
 
+  /**
+  * `put` is called on child (result of promise) in `updateDirectChild`
+  * Then for the outermost parent, `put` should be called manually.
+  */
   async updateChild(child: Tree | File, path: Path): Promise<this> {
     const chain: [string, Tree][] = []
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -703,7 +703,10 @@ export class FileSystem {
     return result
   }
 
-  /** @internal */
+  /** @internal
+  * `put` should be called on the node returned from the function.
+  * Normally this is handled by `runOnNode`.
+  */
   async runOnChildTree(node: Tree, relPath: Path, fn: (tree: Tree) => Promise<Tree>): Promise<Tree> {
     let tree = node
 

--- a/src/fs/protocol/private/mmpt.ts
+++ b/src/fs/protocol/private/mmpt.ts
@@ -1,7 +1,9 @@
 import { AddResult, CID } from "../../../ipfs/index.js"
+import { Puttable, SimpleLinks } from "../../types.js"
+import { setup } from "../../../setup/internal.js"
 import * as basic from "../basic.js"
 import * as link from "../../link.js"
-import { Puttable, SimpleLinks } from "../../types.js"
+
 
 const nibbles = {
   "0": true, "1": true, "2": true, "3": true, "4": true, "5": true, "6": true, "7": true,
@@ -55,7 +57,11 @@ export default class MMPT implements Puttable {
 
     // if already in tree, then skip
     if (name === nextNameOrSib) {
-      // skip
+      if (setup.debug && this.links[name]?.cid !== value) {
+        console.warn(`Adding \`${name}\` to the MMPT again with a different value. This should not happen. The original value will still be used and can loading issues on other ipfs repos. Current CID is \`${this.links[name]?.cid}\`, new CID is \`${value}\`.`)
+      } else {
+        // skip
+      }
     }
 
     // if no children starting with first char of name, then add with entire name as key


### PR DESCRIPTION
This was causing the "Shared with me" folder not to load on my other devices. Because `.put()` was called multiple times on that folder, causing it to be added multiple times to the MMPT with different CIDs. `.put()` produces different CIDs every time because the AES encryption is done with a random `iv` value, and the MMPT doesn't allow addition of the same key/namefilter multiple times (it will keep the first, original, value).

- Removes multiple `put` calls
- Adds MMPT warning in case this happens elsewhere