### PR TITLE
Rejection Sampling in Pin Gen, AWAKE

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ipfs-message-port-client": "^0.10.3",
     "ipfs-message-port-protocol": "^0.10.5",
     "ipld-dag-pb": "^0.22.3",
-    "keystore-idb": "^0.15.4",
+    "keystore-idb": "^0.15.5",
     "localforage": "^1.10.0",
     "multiformats": "^9.5.4",
     "one-webcrypto": "^1.0.3",

--- a/src/auth/linking/consumer.ts
+++ b/src/auth/linking/consumer.ts
@@ -221,7 +221,7 @@ export const handleSessionKey = async (temporaryRsaPrivateKey: CryptoKey, data: 
  * @returns pin and challenge message
  */
 export const generateUserChallenge = async (sessionKey: CryptoKey): Promise<{ pin: Uint8Array; challenge: string }> => {
-  const pin = new Uint8Array(utils.randomBuf(6, 9))
+  const pin = new Uint8Array(utils.randomBuf(6, { max: 9 }))
 
   const iv = utils.randomBuf(16)
   const msg = await aes.encrypt(JSON.stringify({

--- a/src/auth/linking/consumer.ts
+++ b/src/auth/linking/consumer.ts
@@ -74,7 +74,7 @@ export const createConsumer = async (options: { username: string }): Promise<Acc
           handleLinkingError(sessionKeyResult.error)
         }
       }
-    } else if (ls.step === LinkingStep.Delegation){
+    } else if (ls.step === LinkingStep.Delegation) {
       if (!ls.sessionKey) {
         handleLinkingError(new LinkingError("Consumer was missing session key when linking device"))
       } else if (!ls.username) {
@@ -221,16 +221,7 @@ export const handleSessionKey = async (temporaryRsaPrivateKey: CryptoKey, data: 
  * @returns pin and challenge message
  */
 export const generateUserChallenge = async (sessionKey: CryptoKey): Promise<{ pin: Uint8Array; challenge: string }> => {
-  const v = utils.randomBuf(6)
-  const pin = new Uint8Array(v).map(n => {
-    // 16 is chosen here because it divides 256 evenly.
-    const modHex = n % 16
-    const hexMax = 15
-    const pinMax = 9
-
-    // This spreads out the sampling bias.
-    return Math.ceil(modHex / hexMax * pinMax)
-  })
+  const pin = new Uint8Array(utils.randomBuf(6, 9))
 
   const iv = utils.randomBuf(16)
   const msg = await aes.encrypt(JSON.stringify({

--- a/src/auth/linking/consumer.ts
+++ b/src/auth/linking/consumer.ts
@@ -121,14 +121,14 @@ export const createConsumer = async (options: { username: string }): Promise<Acc
 }
 
 
-// 🔗 Device Linking Steps 
+// 🔗 Device Linking Steps
 
 /**
  *  BROADCAST
- * 
+ *
  * Generate a temporary RSA keypair and extract a temporary DID from it.
  * The temporary DID will be broadcast on the channel to start the linking process.
- * 
+ *
  * @returns temporary RSA key pair and temporary DID
  */
 export const generateTemporaryExchangeKey = async (): Promise<{ temporaryRsaPair: CryptoKeyPair; temporaryDID: string }> => {
@@ -143,13 +143,13 @@ export const generateTemporaryExchangeKey = async (): Promise<{ temporaryRsaPair
 
 /**
  *  NEGOTIATION
- * 
+ *
  * Decrypt the session key and check the closed UCAN for capability.
  * The session key is encrypted with the temporary RSA keypair.
  * The closed UCAN is encrypted with the session key.
- * 
+ *
  * @param temporaryRsaPrivateKey
- * @param data 
+ * @param data
  * @returns AES session key
  */
 export const handleSessionKey = async (temporaryRsaPrivateKey: CryptoKey, data: string): Promise<Result<CryptoKey, Error>> => {
@@ -214,15 +214,22 @@ export const handleSessionKey = async (temporaryRsaPrivateKey: CryptoKey, data: 
 
 /**
  * NEGOTIATION
- * 
- * Generate pin and challenge message for verification by the producer. 
- * 
+ *
+ * Generate pin and challenge message for verification by the producer.
+ *
  * @param sessionKey
  * @returns pin and challenge message
  */
 export const generateUserChallenge = async (sessionKey: CryptoKey): Promise<{ pin: Uint8Array; challenge: string }> => {
-  const pin = new Uint8Array(utils.randomBuf(6)).map(n => {
-    return n % 10
+  const v = utils.randomBuf(6)
+  const pin = new Uint8Array(v).map(n => {
+    // 16 is chosen here because it divides 256 evenly.
+    const modHex = n % 16
+    const hexMax = 15
+    const pinMax = 9
+
+    // This spreads out the sampling bias.
+    return Math.ceil(modHex / hexMax * pinMax)
   })
 
   const iv = utils.randomBuf(16)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,10 +3411,10 @@ k-bucket@^5.1.0:
   dependencies:
     randombytes "^2.1.0"
 
-keystore-idb@^0.15.4:
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.15.4.tgz#ba2387a6a6284421f023c0719d099eb9d2c9cfa8"
-  integrity sha512-3HfkebZQzo7iFA301aXTizupfwlWk350uwCjdUY2p6v9jVP0B1frySTgesInqjHaj66mpridvg8WNF43JErEQg==
+keystore-idb@^0.15.5:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/keystore-idb/-/keystore-idb-0.15.5.tgz#7841362be09de0dedb86ed5fe16f6bcba46a0b91"
+  integrity sha512-7bcUAnY5iD0+N75odQVTCs8mhXBW+yLt9/HH8+VUrl44FGllpAhu7q3/w9QpNMHxLQv3OXs1fsA042CAviN79Q==
   dependencies:
     localforage "^1.10.0"
     one-webcrypto "^1.0.3"


### PR DESCRIPTION
## Summary

This PR fixes the following **issues**

* [x] Sampling bias towards low numbers

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Currently pin sampling method has a slight bias towards low numbers (0-5). This PR gets rid of this bias with updated `randomBuf` implementation that takes a max param and uses rejection sampling. 

## Test plan (required)

Making sure existing tests around pin generation still pass. 

```bash
yarn test:prod -g "generates a pin and challenge message"
```

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #359

## Depends On

- [x] https://github.com/fission-suite/keystore-idb/pull/65
  - [x] Need to update keystore-idb version when it gets merged and published. 
