### PR TITLE
Type-Check CID

### DIFF
--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -132,5 +132,5 @@ const attemptPin = async (cid: CID): Promise<void> => {
 }
 
 const typeCheckCID = (cid: CID): void => {
-  if (!CID.asCID(cid)) throw new Error("Expected a CID object")
+  if (!CID.asCID(cid)) throw new Error(`Expected a CID object = ${cid}`)
 }

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -28,6 +28,8 @@ export const add = async (content: ImportCandidate): Promise<AddResult> => {
 }
 
 export const catRaw = async (cid: CID): Promise<Uint8Array[]> => {
+  typeCheckCID(cid)
+
   const ipfs = await getIpfs()
   const chunks = []
   await attemptPin(cid)
@@ -38,16 +40,22 @@ export const catRaw = async (cid: CID): Promise<Uint8Array[]> => {
 }
 
 export const catBuf = async (cid: CID): Promise<Uint8Array> => {
+  typeCheckCID(cid)
+
   const raw = await catRaw(cid)
   return uint8arrays.concat(raw)
 }
 
 export const cat = async (cid: CID): Promise<string> => {
+  typeCheckCID(cid)
+
   const buf = await catBuf(cid)
   return buf.toString()
 }
 
 export const ls = async (cid: CID): Promise<IPFSEntry[]> => {
+  typeCheckCID(cid)
+
   const ipfs = await getIpfs()
   const links = []
   for await (const link of ipfs.ls(cid)) {
@@ -57,6 +65,8 @@ export const ls = async (cid: CID): Promise<IPFSEntry[]> => {
 }
 
 export const dagGet = async (cid: CID): Promise<PBNode> => {
+  typeCheckCID(cid)
+
   const ipfs = await getIpfs()
   await attemptPin(cid)
   const raw = await ipfs.dag.get(cid)
@@ -99,12 +109,16 @@ export const dagPutLinks = async (links: PBLink[]): Promise<AddResult> => {
 }
 
 export const size = async (cid: CID): Promise<number> => {
+  typeCheckCID(cid)
+
   const ipfs = await getIpfs()
   const stat = await ipfs.files.stat(`/ipfs/${cid}`)
   return stat.cumulativeSize
 }
 
 export const attemptPin = async (cid: CID): Promise<void> => {
+  typeCheckCID(cid)
+
   if (!setup.shouldPin) return
 
   const ipfs = await getIpfs()
@@ -117,4 +131,8 @@ export const attemptPin = async (cid: CID): Promise<void> => {
       throw err
     }
   }
+}
+
+const typeCheckCID = (cid: CID): void => {
+  if (!CID.asCID(cid)) throw new Error("Expected a CID object")
 }

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -116,9 +116,7 @@ export const size = async (cid: CID): Promise<number> => {
   return stat.cumulativeSize
 }
 
-export const attemptPin = async (cid: CID): Promise<void> => {
-  typeCheckCID(cid)
-
+const attemptPin = async (cid: CID): Promise<void> => {
   if (!setup.shouldPin) return
 
   const ipfs = await getIpfs()

--- a/src/ipfs/basic.ts
+++ b/src/ipfs/basic.ts
@@ -28,48 +28,48 @@ export const add = async (content: ImportCandidate): Promise<AddResult> => {
 }
 
 export const catRaw = async (cid: CID): Promise<Uint8Array[]> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
   const ipfs = await getIpfs()
   const chunks = []
-  await attemptPin(cid)
-  for await (const chunk of ipfs.cat(cid)) {
+  await attemptPin(newCID)
+  for await (const chunk of ipfs.cat(newCID)) {
     chunks.push(chunk)
   }
   return chunks
 }
 
 export const catBuf = async (cid: CID): Promise<Uint8Array> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
-  const raw = await catRaw(cid)
+  const raw = await catRaw(newCID)
   return uint8arrays.concat(raw)
 }
 
 export const cat = async (cid: CID): Promise<string> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
-  const buf = await catBuf(cid)
+  const buf = await catBuf(newCID)
   return buf.toString()
 }
 
 export const ls = async (cid: CID): Promise<IPFSEntry[]> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
   const ipfs = await getIpfs()
   const links = []
-  for await (const link of ipfs.ls(cid)) {
+  for await (const link of ipfs.ls(newCID)) {
     links.push({ ...link, cid: decodeCID(link.cid) })
   }
   return links
 }
 
 export const dagGet = async (cid: CID): Promise<PBNode> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
   const ipfs = await getIpfs()
-  await attemptPin(cid)
-  const raw = await ipfs.dag.get(cid)
+  await attemptPin(newCID)
+  const raw = await ipfs.dag.get(newCID)
   const node = util.rawToDAGNode(raw)
   return node
 }
@@ -109,10 +109,10 @@ export const dagPutLinks = async (links: PBLink[]): Promise<AddResult> => {
 }
 
 export const size = async (cid: CID): Promise<number> => {
-  typeCheckCID(cid)
+  const newCID = typeCheckCID(cid)
 
   const ipfs = await getIpfs()
-  const stat = await ipfs.files.stat(`/ipfs/${cid}`)
+  const stat = await ipfs.files.stat(`/ipfs/${newCID}`)
   return stat.cumulativeSize
 }
 
@@ -131,6 +131,8 @@ const attemptPin = async (cid: CID): Promise<void> => {
   }
 }
 
-const typeCheckCID = (cid: CID): void => {
-  if (!CID.asCID(cid)) throw new Error(`Expected a CID object = ${cid}`)
+const typeCheckCID = (cid: CID): CID => {
+  const newCID = CID.asCID(cid)
+  if (!newCID) throw new Error(`Expected a CID class instance: Found ${cid}`)
+  return newCID
 }

--- a/tests/fs/share.node.test.ts
+++ b/tests/fs/share.node.test.ts
@@ -83,7 +83,7 @@ describe("the filesystem", () => {
     ))
 
     const entryIndexInfo = JSON.parse(new TextDecoder().decode(await crypto.aes.decrypt(
-      await protocol.basic.getFile(decryptedPayload.cid),
+      await protocol.basic.getFile(decodeCID(decryptedPayload.cid)),
       uint8arrays.toString(decryptedPayload.key, "base64pad"),
       SymmAlg.AES_GCM
     )))


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Type-checks CID for better error message

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

`cid`s have been updated to use the multiformat-based CID class but old code still use string encoded formats which leads to vague errors. This PR adds a check that returns a clear error message when a cid parameter isn't an object.

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #345