### PR TITLE
Fix Initial Delay in DID lookup

### DIFF
--- a/src/auth/channel.ts
+++ b/src/auth/channel.ts
@@ -43,19 +43,23 @@ export const createWssChannel = async (options: ChannelOptions): Promise<Channel
 }
 
 const waitForRootDid = async (username: string): Promise<string | null> => {
+  let rootDid: string | null = await did.root(username)
+  if (rootDid) {
+    return rootDid
+  }
+
   return new Promise((resolve) => {
-    const maxTries = 3
+    const maxRetries = 3
     let tries = 0
-    let rootDid: string | null = null
 
     const rootDidInterval = setInterval(async () => {
+      console.log("Could not fetch root DID. Retrying")
       rootDid = await did.root(username).catch((e) => {
         clearInterval(rootDidInterval)
         throw e
       })
 
-      if (!rootDid && tries < maxTries) {
-        console.log("Could not fetch root DID. Retrying")
+      if (!rootDid && tries < maxRetries) {
         tries++
         return
       }


### PR DESCRIPTION
## Summary
<!-- Summary of the PR -->

This PR fixes the following **bug**

* [x] Initial delay in DID lookup

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

PR #367 implements root DID lookup retrying but does not address the initial 2 sec delay from `setInterval` as noted by @icidasset. This PR fixes that.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

## Test plan (required)

```sh
yarn test
```

