### PR TITLE
App owned: Add use WNFS implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### v0.33.0
+
+#### Features
+
+Adds app owned WNFS.
 
 ### v0.32.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Fission Webnative SDK",
   "keywords": [
     "WebCrypto",

--- a/src/auth/implementation/base.ts
+++ b/src/auth/implementation/base.ts
@@ -1,14 +1,14 @@
-import type { Channel, ChannelOptions } from "./channel"
+import type { Channel, ChannelOptions } from "../channel"
 
-import { USERNAME_STORAGE_KEY } from "../common/index.js"
-import { State } from "./state.js"
-import { createAccount } from "../lobby/index.js"
+import { USERNAME_STORAGE_KEY } from "../../common/index.js"
+import { State } from "../state.js"
+import { createAccount } from "../../lobby/index.js"
 
-import * as channel from "./channel.js"
-import * as did from "../did/index.js"
-import * as storage from "../storage/index.js"
-import * as ucan from "../ucan/index.js"
-import * as user from "../lobby/username.js"
+import * as channel from "../channel.js"
+import * as did from "../../did/index.js"
+import * as storage from "../../storage/index.js"
+import * as ucan from "../../ucan/index.js"
+import * as user from "../../lobby/username.js"
 
 
 export const init = async (): Promise<State | null> => {
@@ -87,7 +87,7 @@ export const linkDevice = async (data: Record<string, unknown>): Promise<void> =
 // 🛳
 
 
-export const LOCAL_IMPLEMENTATION = {
+export const BASE_IMPLEMENTATION = {
   auth: {
     init,
     register,

--- a/src/auth/implementation/use-wnfs.ts
+++ b/src/auth/implementation/use-wnfs.ts
@@ -55,6 +55,7 @@ export const linkDevice = async (data: Record<string, unknown>): Promise<void> =
       issuer
     })
     await ucanInternal.store([ucan.encode(fsUcan)])
+
   } else {
     throw new LinkingError(`Consumer received invalid link device response from producer. Given ucan is invalid: ${data.ucan}`)
   }

--- a/src/auth/implementation/use-wnfs.ts
+++ b/src/auth/implementation/use-wnfs.ts
@@ -1,0 +1,79 @@
+import * as base from "./base.js"
+import * as check from "../../common/type-checks.js"
+import * as did from "../../did/index.js"
+import * as storage from "../../storage/index.js"
+import * as ucanInternal from "../../ucan/internal.js"
+import * as ucan from "../../ucan/token.js"
+import { LinkingError } from "../linking.js"
+
+export const delegateAccount = async (username: string, audience: string): Promise<Record<string, unknown>> => {
+  const readKey = await storage.getItem("readKey")
+  const proof = await storage.getItem("ucan") as string
+
+  // UCAN
+  const u = await ucan.build({
+    audience,
+    issuer: await did.write(),
+    lifetimeInSeconds: 60 * 60 * 24 * 30 * 12 * 1000, // 1000 years
+    potency: "SUPER_USER",
+    proof,
+
+    // TODO: UCAN v0.7.0
+    // proofs: [ await localforage.getItem("ucan") ]
+  })
+
+  return { readKey, ucan: ucan.encode(u) }
+}
+
+function isUseWnfsLinkingData(data: unknown): data is { readKey: string; ucan: string } {
+  return check.isObject(data)
+    && "readKey" in data && typeof data.readKey === "string"
+    && "ucan" in data && typeof data.ucan === "string"
+}
+
+export const linkDevice = async (data: Record<string, unknown>): Promise<void> => {
+  if (!isUseWnfsLinkingData(data)) {
+    throw new LinkingError(`Consumer received invalid link device response from producer: Expected read key and ucan, but got ${JSON.stringify(data)}`)
+  }
+
+  const { readKey, ucan: encodedToken } = data
+  const u = ucan.decode(encodedToken as string)
+
+  if (await ucan.isValid(u)) {
+    await storage.setItem("ucan", encodedToken)
+    await storage.setItem("readKey", readKey)
+
+    // Create and store filesystem UCAN
+    const issuer = await did.write()
+    const fsUcan = await ucan.build({
+      potency: "APPEND",
+      resource: "*",
+      proof: encodedToken,
+      lifetimeInSeconds: 60 * 60 * 24 * 30 * 12 * 1000, // 1000 years
+
+      audience: issuer,
+      issuer
+    })
+    await ucanInternal.store([ucan.encode(fsUcan)])
+  } else {
+    throw new LinkingError(`Consumer received invalid link device response from producer. Given ucan is invalid: ${data.ucan}`)
+  }
+}
+
+
+
+// 🛳
+
+
+export const USE_WNFS_IMPLEMENTATION = {
+  auth: {
+    init: base.init,
+    register: base.register,
+    isUsernameValid: base.isUsernameValid,
+    isUsernameAvailable: base.isUsernameAvailable,
+    createChannel: base.createChannel,
+    checkCapability: base.checkCapability,
+    delegateAccount,
+    linkDevice
+  }
+}

--- a/src/auth/implementation/use-wnfs.ts
+++ b/src/auth/implementation/use-wnfs.ts
@@ -6,6 +6,8 @@ import * as ucanInternal from "../../ucan/internal.js"
 import * as ucan from "../../ucan/token.js"
 import { LinkingError } from "../linking.js"
 
+import RootTree from "../../fs/root/tree.js"
+
 export const delegateAccount = async (username: string, audience: string): Promise<Record<string, unknown>> => {
   const readKey = await storage.getItem("readKey")
   const proof = await storage.getItem("ucan") as string
@@ -42,6 +44,8 @@ export const linkDevice = async (data: Record<string, unknown>): Promise<void> =
   if (await ucan.isValid(u)) {
     await storage.setItem("ucan", encodedToken)
     await storage.setItem("readKey", readKey)
+
+    await RootTree.storeRootKey(readKey)
 
     // Create and store filesystem UCAN
     const issuer = await did.write()

--- a/src/auth/linking/consumer.test.ts
+++ b/src/auth/linking/consumer.test.ts
@@ -10,7 +10,7 @@ import utils from "keystore-idb/lib/utils.js"
 import * as did from "../../../src/did/index.js"
 import * as consumer from "./consumer.js"
 import * as ucan from "../../ucan/index.js"
-import { LOCAL_IMPLEMENTATION } from "../local.js"
+import { BASE_IMPLEMENTATION } from "../implementation/base.js"
 import { setImplementations } from "../../setup.js"
 
 describe("generate temporary exchange key", async () => {
@@ -314,7 +314,7 @@ describe("link device", async () => {
   before(async () => {
     setImplementations({
       auth: {
-        ...LOCAL_IMPLEMENTATION.auth,
+        ...BASE_IMPLEMENTATION.auth,
         linkDevice
       }
     })

--- a/src/auth/linking/producer.test.ts
+++ b/src/auth/linking/producer.test.ts
@@ -9,7 +9,7 @@ import utils from "keystore-idb/lib/utils.js"
 import * as did from "../../../src/did/index.js"
 import * as producer from "./producer.js"
 import * as ucan from "../../ucan/index.js"
-import { LOCAL_IMPLEMENTATION } from "../local.js"
+import { BASE_IMPLEMENTATION } from "../implementation/base.js"
 import { setImplementations } from "../../setup.js"
 
 describe("generate session key", async () => {
@@ -208,7 +208,7 @@ describe("delegate account", async () => {
   before(async () => {
     setImplementations({
       auth: {
-        ...LOCAL_IMPLEMENTATION.auth,
+        ...BASE_IMPLEMENTATION.auth,
         delegateAccount
       }
     })

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.32.0"
+export const VERSION = "0.33.0"

--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -1,0 +1,39 @@
+import expect from "expect"
+
+import { Storage } from "../tests/storage/inMemory.js"
+import { readKey } from "./filesystem.js"
+import { setImplementations } from "./setup.js"
+
+describe("read key", () => {
+  const store = new Storage()
+
+  before(() => {
+    setImplementations({
+      storage: {
+        getItem: store.getItem,
+        setItem: store.setItem,
+        removeItem: store.removeItem,
+        clear: store.clear
+      }
+    })
+
+  })
+
+  afterEach(async () => {
+    await store.clear()
+  })
+
+  it("creates and stores a key", async () => {
+    await readKey()
+
+    const key = store.getItem("readKey")
+    expect(key).toBeDefined()
+  })
+
+  it("recovers a stored key", async () => {
+    const storedKey = await readKey()
+
+    const key = await readKey()
+    expect(key).toEqual(storedKey)
+  })
+})

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -189,6 +189,9 @@ async function addSampleData(fs: FileSystem): Promise<void> {
 // 🔑
 
 
+/**
+ * Create or get a read key for accessing the WNFS private root.
+ */
 export async function readKey(): Promise<string> {
   const maybeReadKey = await storage.getItem("readKey") as unknown as string
   if (maybeReadKey) return maybeReadKey

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -102,11 +102,13 @@ export async function loadFileSystem(
 
 
 /**
- * Create a filesystem
+ * Create a new filesystem and assign it to a user.
+ *
+ * Warning: This function will override a user's filesystem with a empty one.
  *
  * @param permissions The permissions to initialize the filesystem
  */
-export const createFilesystem = async (permissions: Permissions): Promise<FileSystem> => {
+export const installFileSystem = async (permissions: Permissions): Promise<FileSystem> => {
   // Get or create root read key
   const rootKey = await readKey()
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -8,11 +8,11 @@ import * as crypto from "./crypto/index.js"
 import * as debug from "./common/debug.js"
 import * as dataRoot from "./data-root.js"
 import * as did from "./did/index.js"
+import * as token from "./ucan/token.js"
 import * as ucan from "./ucan/internal.js"
 import * as protocol from "./fs/protocol/index.js"
 import * as versions from "./fs/versions.js"
 
-import { build as buildUcan, encode as encodeUcan } from "./ucan/token.js"
 import { Branch } from "./path.js"
 import { Maybe, authenticatedUsername, decodeCID } from "./common/index.js"
 import { Permissions } from "./ucan/permissions.js"
@@ -112,7 +112,7 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
   // Self-authorize a filesystem UCAN
   const issuer = await did.write()
   const proof: string | null = await localforage.getItem("ucan")
-  const fsUcan = await buildUcan({
+  const fsUcan = await token.build({
     potency: "APPEND",
     resource: "*",
     proof: proof ? proof : undefined,
@@ -124,14 +124,14 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
   console.log("fsUcan", fsUcan)
 
   // Add filesystem UCAN to store
-  await ucan.store([encodeUcan(fsUcan)])
+  await ucan.store([token.encode(fsUcan)])
 
   // Update filesystem
   const rootCid = await fs.root.put()
   console.log("root cid", rootCid)
 
   // Publish data root
-  const res = await dataRoot.update(rootCid, encodeUcan(fsUcan))
+  const res = await dataRoot.update(rootCid, token.encode(fsUcan))
   // throw an error on failure?
   console.log("data root update result", res)
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -130,9 +130,7 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
   await ucan.store([token.encode(fsUcan)])
 
   // Update filesystem and publish data root
-  const rootCid = await fs.root.put()
-  const res = await dataRoot.update(rootCid, token.encode(fsUcan))
-  if (!res.success) console.warn("Failed to update data root.")
+  const rootCid = await fs.publish()
 
   // Clear the CID log and update it
   await cidLog.clear()

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -188,7 +188,7 @@ async function addSampleData(fs: FileSystem): Promise<void> {
 // 🔑
 
 
-async function readKey(): Promise<string> {
+export async function readKey(): Promise<string> {
   const maybeReadKey = await storage.getItem("readKey") as unknown as string
   if (maybeReadKey) return maybeReadKey
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -103,11 +103,9 @@ export async function loadFileSystem(
 export const createFilesystem = async (permissions: Permissions): Promise<FileSystem> => {
   // Get or create root read key
   const rootKey = await readKey()
-  console.log("root key", rootKey)
 
   // Create an empty filesystem
   const fs = await FileSystem.empty({ permissions, rootKey })
-  console.log("empty filesystem", fs)
 
   // Self-authorize a filesystem UCAN
   const issuer = await did.write()
@@ -121,16 +119,12 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
     audience: issuer,
     issuer
   })
-  console.log("fsUcan", fsUcan)
 
   // Add filesystem UCAN to store
   await ucan.store([token.encode(fsUcan)])
 
-  // Update filesystem
+  // Update filesystem and publish data root
   const rootCid = await fs.root.put()
-  console.log("root cid", rootCid)
-
-  // Publish data root
   const res = await dataRoot.update(rootCid, token.encode(fsUcan))
   // throw an error on failure?
   console.log("data root update result", res)

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -108,7 +108,7 @@ export async function loadFileSystem(
  *
  * @param permissions The permissions to initialize the filesystem
  */
-export const installFileSystem = async (permissions: Permissions): Promise<FileSystem> => {
+export const bootstrapFileSystem = async (permissions: Permissions): Promise<FileSystem> => {
   // Get or create root read key
   const rootKey = await readKey()
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -7,10 +7,11 @@ import * as crypto from "./crypto/index.js"
 import * as debug from "./common/debug.js"
 import * as dataRoot from "./data-root.js"
 import * as did from "./did/index.js"
+import * as pathing from "./path.js"
+import * as protocol from "./fs/protocol/index.js"
 import * as storage from "./storage/index.js"
 import * as token from "./ucan/token.js"
 import * as ucan from "./ucan/internal.js"
-import * as protocol from "./fs/protocol/index.js"
 import * as versions from "./fs/versions.js"
 
 import { Branch } from "./path.js"
@@ -168,6 +169,28 @@ export async function checkFileSystemVersion(filesystemCID: CID): Promise<void> 
   }
 }
 
+
+
+// ROOT HELPERS
+
+
+const ROOT_PERMISSIONS = { fs: { private: [pathing.root()], public: [pathing.root()] } }
+
+/**
+ * Load a user's root file system.
+ */
+ export const loadRootFileSystem = async (): Promise<FileSystem> => {
+  return await loadFileSystem(ROOT_PERMISSIONS)
+}
+
+/**
+ * Create a new filesystem with public and private roots and assign it to a user.
+ *
+ * Warning: This function will override a user's filesystem with an empty one.
+ */
+ export const bootstrapRootFileSystem = async (): Promise<FileSystem> => {
+  return await bootstrapFileSystem(ROOT_PERMISSIONS)
+ }
 
 
 

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -134,7 +134,8 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
   const res = await dataRoot.update(rootCid, token.encode(fsUcan))
   if (!res.success) console.warn("Failed to update data root.")
 
-  // Update CID log
+  // Clear the CID log and update it
+  await cidLog.clear()
   await cidLog.add(rootCid.toString())
 
   return fs

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -216,7 +216,7 @@ async function addSampleData(fs: FileSystem): Promise<void> {
  * Create or get a read key for accessing the WNFS private root.
  */
 export async function readKey(): Promise<string> {
-  const maybeReadKey = await storage.getItem("readKey") as unknown as string
+  const maybeReadKey: string | null = await storage.getItem("readKey")
   if (maybeReadKey) return maybeReadKey
 
   const readKey = await crypto.aes.genKeyStr()

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -104,7 +104,7 @@ export async function loadFileSystem(
 /**
  * Create a new filesystem and assign it to a user.
  *
- * Warning: This function will override a user's filesystem with a empty one.
+ * Warning: This function will override a user's filesystem with an empty one.
  *
  * @param permissions The permissions to initialize the filesystem
  */

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -126,8 +126,7 @@ export const createFilesystem = async (permissions: Permissions): Promise<FileSy
   // Update filesystem and publish data root
   const rootCid = await fs.root.put()
   const res = await dataRoot.update(rootCid, token.encode(fsUcan))
-  // throw an error on failure?
-  console.log("data root update result", res)
+  if (!res.success) console.warn("Failed to update data root.")
 
   // Update CID log
   await cidLog.add(rootCid.toString())

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,6 @@ export async function initialise(options: InitOptions): Promise<State> {
     }
 
   } else if (authedUsername && useWnfs) {
-    if (options.loadFileSystem === false) throw new Error("Must load filesystem when using the useWnfs option.")
-
     const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server or DNS
     const logCid = await cidLog.newest() // data root in browser
     const rootPermissions = { fs: { private: [pathing.root()], public: [pathing.root()] } }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,12 @@ export async function initialise(options: InitOptions): Promise<State> {
 }
 
 
+/**
+ * Alias for `initialise`.
+ */
+ export { initialise as initialize }
+
+
 
 // SUPPORTED
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as ucan from "./ucan/internal.js"
 
 import { InitOptions, InitialisationError } from "./init/types.js"
 import { State, scenarioContinuation, scenarioNotAuthorised, validateSecrets } from "./auth/state.js"
-import { createFilesystem, loadFileSystem } from "./filesystem.js"
+import { installFileSystem, loadFileSystem } from "./filesystem.js"
 
 import FileSystem from "./fs/index.js"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,8 @@ export async function initialise(options: InitOptions): Promise<State> {
   } else if (authedUsername && useWnfs) {
     if (options.loadFileSystem === false) throw new Error("Must load filesystem when using the useWnfs option.")
 
-    const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server
-    const logCid = await cidLog.newest() // data root in app
+    const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server or DNS
+    const logCid = await cidLog.newest() // data root in browser
     const rootPermissions = { fs: { private: [pathing.root()], public: [pathing.root()] } }
 
     if (dataCid === null && logCid === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export async function initialise(options: InitOptions): Promise<State> {
       return scenarioContinuation(
         rootPermissions,
         authedUsername,
-        await createFilesystem(rootPermissions)
+        await installFileSystem(rootPermissions)
       )
     } else {
       const fs = options.loadFileSystem === false ?

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export async function initialise(options: InitOptions): Promise<State> {
 /**
  * Alias for `initialise`.
  */
- export { initialise as initialize }
+export { initialise as initialize }
 
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import * as ucan from "./ucan/internal.js"
 
 import { InitOptions, InitialisationError } from "./init/types.js"
 import { State, scenarioContinuation, scenarioNotAuthorised, validateSecrets } from "./auth/state.js"
-import { installFileSystem, loadFileSystem } from "./filesystem.js"
+import { bootstrapFileSystem, loadFileSystem } from "./filesystem.js"
 
 import FileSystem from "./fs/index.js"
 
@@ -74,7 +74,7 @@ export async function initialise(options: InitOptions): Promise<State> {
       return scenarioContinuation(
         rootPermissions,
         authedUsername,
-        await installFileSystem(rootPermissions)
+        await bootstrapFileSystem(rootPermissions)
       )
     } else {
       const fs = options.loadFileSystem === false ?

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,10 +77,14 @@ export async function initialise(options: InitOptions): Promise<State> {
         await createFilesystem(rootPermissions)
       )
     } else {
+      const fs = options.loadFileSystem === false ?
+        undefined :
+        await loadFileSystem(rootPermissions, authedUsername)
+
       return scenarioContinuation(
         rootPermissions,
         authedUsername,
-        await maybeLoadFs(authedUsername),
+        fs
       )
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export async function initialise(options: InitOptions): Promise<State> {
   } else if (authedUsername && useWnfs) {
     if (options.loadFileSystem === false) throw new Error("Must load filesystem when using the useWnfs option.")
 
-    const dataCid = await dataRoot.lookup(authedUsername) // data root on server
+    const dataCid = navigator.onLine ? await dataRoot.lookup(authedUsername) : null // data root on server
     const logCid = await cidLog.newest() // data root in app
     const rootPermissions = { fs: { private: [pathing.root()], public: [pathing.root()] } }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,6 @@ export async function initialise(options: InitOptions): Promise<State> {
       return scenarioNotAuthorised(permissions)
     }
 
-  // Is this the right set of conditions? For now, this should only include root apps
   } else if (authedUsername && useWnfs) {
     if (options.loadFileSystem === false) throw new Error("Must load filesystem when using the useWnfs option.")
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ import FileSystem from "./fs/index.js"
  *
  * See `loadFileSystem` if you want to load the user's file system yourself.
  * NOTE: Only works on the main/ui thread, as it uses `window.location`.
+ *
+ * The `useWnfs` option is only necessary for apps that create their own WNFS. Apps that
+ * request filesystem `permissions` from the auth lobby can ignore `useWnfs` in this version
+ * of webnative.
  */
 export async function initialise(options: InitOptions): Promise<State> {
   options = options || {}

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -17,6 +17,7 @@ export type InitOptions = {
 
   // Options
   autoRemoveUrlParams?: boolean
+  useWnfs?: boolean
   loadFileSystem?: boolean
   rootKey?: string
 }

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -17,7 +17,7 @@ export type InitOptions = {
 
   // Options
   autoRemoveUrlParams?: boolean
-  useWnfs?: boolean
   loadFileSystem?: boolean
   rootKey?: string
+  useWnfs?: boolean
 }

--- a/tests/auth/linking.node.test.ts
+++ b/tests/auth/linking.node.test.ts
@@ -1,6 +1,6 @@
 import expect from "expect"
 
-import { LOCAL_IMPLEMENTATION } from "../../src/auth/local.js"
+import { BASE_IMPLEMENTATION } from "../../src/auth/implementation/base.js"
 import { createConsumer } from "../../src/auth/linking/consumer.js"
 import { createProducer } from "../../src/auth/linking/producer.js"
 import { EventEmitter } from "../../src/common/event-emitter.js"
@@ -61,7 +61,7 @@ describe("account linking", () => {
 
     setImplementations({
       auth: {
-        ...LOCAL_IMPLEMENTATION.auth,
+        ...BASE_IMPLEMENTATION.auth,
         createChannel,
         checkCapability,
         delegateAccount,


### PR DESCRIPTION
## Summary

This PR makes it possible for apps to create WNFS without visiting the auth lobby.

This PR implements the following **features**

* [x] Adds a `useWnfs` option that creates or loads WNFS in apps with root authority (app-owned auth apps)
* [x] Adds a `USE_WNFS_IMPLEMENTATION` to provide account linking for apps that `useWnfs`
* [x] Rename `LOCAL_IMPLEMENTATION` to `BASE_IMPLEMENTATION`

The features in the PR will only make sense for apps with root authority. We can make these features coherent for linked apps when we implement app-owned app linking. For now, apps that initialize webnative with `permissions` will ignore the `useWnfs` option.

### `useWnfs` option

The `useWnfs` option is passed to `webnative.initialize`:

``` typescript
wn.initialise({ useWnfs: true })
  .then(async (state: State) => {
    switch (state.scenario) {
      case wn.Scenario.Continuation:
        // state.fs available
        
      case wn.Scenario.NotAuthorised:
        // state.fs not available
    })
```

We check if the user has a data root in their CID log, on the server, or in DNS. If any of these exist, we load their existing filesystem. Otherwise, we create a new filesystem with `public` and `private` roots and assign it to the user, which includes creating (or using) a read key, self-authorizing a filesystem UCAN, publishing the data root, and updating the CID log. Taken together, we think of these steps as "bootstrapping" the filesystem.

Developers will bootstrap or load the filesystem in two cases after webnative has already been initialized:

- A user registers an account, and the developer bootstraps a filesystem for them
- A user links a device, and the developer loads their existing filesystem

We provide the developer `bootstrapRootFileSystem` and `loadRootFileSystem` as convenience functions so they do not need to be aware of permissions. Their app has root authority and needs no permission.

### `USE_WNFS_IMPLEMENTATION`

Account linking when using WNFS requires the exchange of a read key. Linking works similar to how it works in the auth lobby, but we also need to configure the linked device with a filesystem UCAN. The `USE_WNFS_IMPLEMENTATION` implements these pieces and must be when using `useWnfs`:

``` typescript
import { USE_WNFS_IMPLEMENTATION } from 'webnative/auth/implementation/use-wnfs'

setImplementations({ auth: USE_WNFS_IMPLEMENTATION.auth })
```

We may ultimately decide to set this implementation for developers automatically. For the moment, this may be confusing for app-owned apps because they will need to use the `BASE_IMPLEMENTATION` when they don't want to use WNFS. In the long run, it may make sense to require the `useWnfs` option in *all* apps that wish to use WNFS. This approach would mean `BASE_IMPLEMENTATION` becomes the default, and `USE_WNFS_IMPLEMENTATION` or other implementations are set during initialization as needed.

### Rename `LOCAL_IMPLEMENTATION` to `BASE_IMPLEMENTATION`

We've discussed elsewhere that the name `LOCAL_IMPLEMENTATION` didn't express its intent clearly enough. Updating it to `BASE_IMPLEMENTATION` makes it clear that the implementation provides a minimal starting point that can be built upon. The `USE_WNFS_IMPLEMENTATION` implementation is an example of building from the base implementation.

## Test plan (required)

Many portions of the code in this PR are effectful in ways that remain challenging to test in webnative. The `initialization` and `createFilesystem` functions rely on data root lookup and update, which use `fetch`. `createFilesystem` and the `USE_WNFS_IMPLEMENTATION` rely on `keystore-db`.

The `readKey` function that gets or creates the read key is tested in `src/filesystem.test.ts`.

## Closing issues

Closes #368.

## After Merge
* [ ] Does this change invalidate any docs or tutorials? No.
* [ ] Does this change require a release to be made? Not immediately, but we may want to create an alpha release.

### Task list

* [x] Add `useWnfs` option to webnative initialize
* [x] Add `createFilesystem` function to create WNFS 
* [x] Create or load WNFS on webnative initialization
* [x] Add `use-wnfs` auth implementation to authorize WNFS when linking accounts
* [x] Ensure backward compatibility for apps that use the auth lobby

