### PR TITLE
Update `register` to make email optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 #### Features
 
-- Adds app owned WNFS.
+- Adds app owned WNFS
 - Separates initialize into app and permissionedApp entrypoints
+- Make email optional at registration
 
 ### v0.32.0
 

--- a/src/auth/implementation/base.ts
+++ b/src/auth/implementation/base.ts
@@ -15,7 +15,7 @@ export const init = async (): Promise<AppState | null> => {
   return new Promise((resolve) => resolve(null))
 }
 
-export const register = async (options: { username: string; email: string }): Promise<{ success: boolean }> => {
+export const register = async (options: { username: string; email?: string }): Promise<{ success: boolean }> => {
   const { success } = await createAccount(options)
 
   if (success) {

--- a/src/auth/implementation/lobby.ts
+++ b/src/auth/implementation/lobby.ts
@@ -95,7 +95,7 @@ export const init = async (options: PermissionedAppInitOptions): Promise<Permiss
   return null
 }
 
-export const register = async (options: { username: string; email: string }): Promise<{ success: boolean }> => {
+export const register = async (options: { username: string; email?: string }): Promise<{ success: boolean }> => {
   return new Promise(resolve => resolve({ success: false }))
 }
 

--- a/src/auth/implementation/types.ts
+++ b/src/auth/implementation/types.ts
@@ -5,7 +5,7 @@ import type { Channel, ChannelOptions } from "../../auth/channel"
 
 export type Implementation = {
   init: (options: InitOptions) => Promise<State | null>
-  register: (options: { email: string; username: string }) => Promise<{ success: boolean }>
+  register: (options: { username: string; email?: string }) => Promise<{ success: boolean }>
   isUsernameValid: (username: string) => Promise<boolean>
   isUsernameAvailable: (username: string) => Promise<boolean>
   createChannel: (options: ChannelOptions) => Promise<Channel>

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,6 +1,6 @@
 import { impl } from "./implementation.js"
 
-export const register = async (options: { username: string; email: string }): Promise<{ success: boolean }> => {
+export const register = async (options: { username: string; email?: string }): Promise<{ success: boolean }> => {
   return impl.register(options)
 }
 

--- a/src/auth/internal.ts
+++ b/src/auth/internal.ts
@@ -9,7 +9,7 @@ export const init = (options: InitOptions): Promise<State | null> => {
   return authLobby.init(options)
 }
 
-export const register = (options: { username: string; email: string }): Promise<{ success: boolean }> => {
+export const register = (options: { username: string; email?: string }): Promise<{ success: boolean }> => {
   return authLobby.register(options)
 }
 

--- a/src/lobby/index.ts
+++ b/src/lobby/index.ts
@@ -14,8 +14,8 @@ export * from "./username.js"
  */
 export async function createAccount(
   userProps: {
-    email: string
     username: string
+    email?: string
   }
 ): Promise<{ success: boolean }> {
   const apiEndpoint = setup.getApiEndpoint()


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Make email optional at registration

This PR makes the email parameter to the `register` function optional. It goes along with the changes on the server (https://github.com/fission-suite/fission/pull/619) where a user can register with a only a username _or_ a username and email.

## Test plan (required)

Tested by registering a user with and without an email.

## Closing issues

Closes #393 

## After Merge
* [x] Does this change invalidate any docs or tutorials? No, but we need new ones in the future.
* [ ] Does this change require a release to be made? Yes, I will release an alpha.
